### PR TITLE
Fix: align Organization and Token label rows in search form

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -65,6 +65,13 @@ describe('App', () => {
     expect(compiled.textContent).toContain('Renovate Dashboard');
   });
 
+  it('should render the title as an h1', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const h1 = fixture.nativeElement.querySelector('h1') as HTMLElement;
+    expect(h1?.textContent?.trim()).toContain('Renovate Dashboard');
+  });
+
   it('should render GitHub link to source repository', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -68,8 +68,9 @@ describe('App', () => {
   it('should render the title as an h1', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
-    const h1 = fixture.nativeElement.querySelector('h1') as HTMLElement;
-    expect(h1?.textContent?.trim()).toContain('Renovate Dashboard');
+    const h1 = fixture.nativeElement.querySelector('h1');
+    expect(h1).toBeTruthy();
+    expect(h1!.textContent?.trim()).toContain('Renovate Dashboard');
   });
 
   it('should render GitHub link to source repository', () => {

--- a/src/app/components/search-form/search-form.component.html
+++ b/src/app/components/search-form/search-form.component.html
@@ -19,7 +19,9 @@
     <!-- Organization + Token inputs -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label for="organization" class="block text-xs font-medium text-ink-2 mb-2">Organization</label>
+        <div class="flex items-center mb-2">
+          <label for="organization" class="text-xs font-medium text-ink-2">Organization</label>
+        </div>
         <input
           id="organization"
           type="text"


### PR DESCRIPTION
## Summary

- The Organization label was a plain `block` element; the Personal Access Token label sits inside a `flex items-center` container (required for the adjacent tooltip button). This height difference caused the two inputs to sit at different vertical positions in the grid — the Organization field appeared slightly higher.
- Fixed by wrapping the Organization label in a matching `flex items-center` container, making both label rows the same height so their inputs align.
- Also includes a previously missed test asserting the app title renders inside an `<h1>` (was written but never committed before the redesign branch was merged).

## Test plan

- [ ] Visually confirm Organization and Personal Access Token inputs are vertically aligned in the search form
- [ ] `npm test` passes (97 tests)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)