### PR TITLE
Fix: pin label row height so Organization and Token inputs align

### DIFF
--- a/src/app/components/search-form/search-form.component.html
+++ b/src/app/components/search-form/search-form.component.html
@@ -19,7 +19,7 @@
     <!-- Organization + Token inputs -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <div class="flex items-center mb-2">
+        <div class="flex items-center h-5 mb-2">
           <label for="organization" class="text-xs font-medium text-ink-2">Organization</label>
         </div>
         <input
@@ -33,7 +33,7 @@
       </div>
 
       <div>
-        <div class="flex items-center gap-1.5 mb-2">
+        <div class="flex items-center gap-1.5 h-5 mb-2">
           <label for="token" class="text-xs font-medium text-ink-2">Personal Access Token</label>
           <div class="relative group">
             <button


### PR DESCRIPTION
## Summary

- The previous fix (#45) matched the flex container structure between the two label rows, but couldn't prevent misalignment caused by the tooltip `<button>` adding implicit line-height space that made the Token label row slightly taller.
- This fix adds an explicit `h-5` (20px) to both label containers, guaranteeing they are the same height regardless of internal content. `h-5` comfortably fits `text-xs` labels (16px line-height) and the 14px tooltip icon.

## Test plan

- [ ] Visually confirm Organization and Personal Access Token inputs are vertically aligned in the search form
- [ ] `npm test` passes (97 tests)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)