### PR TITLE
Feat: default dark mode to system preference instead of always dark

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -46,6 +46,7 @@ function makeGroup(overrides: Partial<PrGroup> = {}): PrGroup {
 function mockMatchMedia(prefersDark: boolean) {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
+    configurable: true,
     value: vi.fn().mockImplementation((query: string) => ({
       matches: query === '(prefers-color-scheme: dark)' ? prefersDark : false,
       media: query,

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -43,8 +43,25 @@ function makeGroup(overrides: Partial<PrGroup> = {}): PrGroup {
   };
 }
 
+function mockMatchMedia(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)' ? prefersDark : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 describe('App', () => {
   beforeEach(async () => {
+    mockMatchMedia(false);
     await TestBed.configureTestingModule({
       imports: [App],
       providers: [provideZonelessChangeDetection()],
@@ -389,9 +406,15 @@ describe('App', () => {
     beforeEach(() => localStorage.clear());
     afterEach(() => localStorage.clear());
 
-    it('defaults to true when no preference is stored', () => {
+    it('defaults to dark when no preference is stored and system prefers dark', () => {
+      mockMatchMedia(true);
       const app = TestBed.createComponent(App).componentInstance;
       expect(app.darkMode()).toBe(true);
+    });
+
+    it('defaults to light when no preference is stored and system prefers light', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      expect(app.darkMode()).toBe(false);
     });
 
     it('initialises to true when localStorage has "dark"', () => {
@@ -407,6 +430,7 @@ describe('App', () => {
     });
 
     it('toggleDarkMode flips the signal each call', () => {
+      mockMatchMedia(true);
       const app = TestBed.createComponent(App).componentInstance;
       expect(app.darkMode()).toBe(true);
 
@@ -419,12 +443,12 @@ describe('App', () => {
 
     it('toggleDarkMode persists the new preference to localStorage', () => {
       const app = TestBed.createComponent(App).componentInstance;
+      // No stored preference + system prefers light → starts as false (light)
+      app.toggleDarkMode(); // false → true
+      expect(localStorage.getItem('theme')).toBe('dark');
 
       app.toggleDarkMode(); // true → false
       expect(localStorage.getItem('theme')).toBe('light');
-
-      app.toggleDarkMode(); // false → true
-      expect(localStorage.getItem('theme')).toBe('dark');
     });
   });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -59,7 +59,12 @@ export class App {
       const stored = localStorage.getItem('theme');
       if (stored) return stored === 'dark';
     } catch { /* storage unavailable */ }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    try {
+      if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches;
+      }
+    } catch { /* matchMedia unavailable */ }
+    return false;
   }
 
   toggleDarkMode(): void {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -59,7 +59,7 @@ export class App {
       const stored = localStorage.getItem('theme');
       if (stored) return stored === 'dark';
     } catch { /* storage unavailable */ }
-    return true;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
   }
 
   toggleDarkMode(): void {

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,12 @@
           } catch (_) { /* matchMedia unavailable — leave as light */ }
         }
       } catch (_) {
-        // localStorage unavailable — leave as light, matching the Angular fallback
+        // localStorage unavailable — mirror Angular's matchMedia fallback to avoid FOUC
+        try {
+          if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (_) { /* matchMedia unavailable — leave as light */ }
       }
     })();
   </script>

--- a/src/index.html
+++ b/src/index.html
@@ -10,14 +10,17 @@
     (function () {
       try {
         var theme = localStorage.getItem('theme');
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (theme === 'dark' || (!theme && prefersDark)) {
+        if (theme === 'dark') {
           document.documentElement.classList.add('dark');
+        } else if (!theme) {
+          try {
+            if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+              document.documentElement.classList.add('dark');
+            }
+          } catch (_) { /* matchMedia unavailable — leave as light */ }
         }
       } catch (_) {
-        // localStorage unavailable (e.g. Safari private mode, blocked storage);
-        // fall back to dark mode default.
-        document.documentElement.classList.add('dark');
+        // localStorage unavailable — leave as light, matching the Angular fallback
       }
     })();
   </script>

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,8 @@
     (function () {
       try {
         var theme = localStorage.getItem('theme');
-        if (theme === 'dark' || !theme) {
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (theme === 'dark' || (!theme && prefersDark)) {
           document.documentElement.classList.add('dark');
         }
       } catch (_) {


### PR DESCRIPTION
## Summary

- Previously, when no `theme` key existed in `localStorage`, the app always defaulted to dark mode.
- Now it checks `window.matchMedia('(prefers-color-scheme: dark)')` so the initial theme follows the user's OS/browser setting.
- The FOUC-prevention inline script in `index.html` is updated with the same logic, ensuring the class applied before Angular boots matches the stored or system preference.
- If the user manually toggles the theme, that choice is still persisted to `localStorage` and takes priority on subsequent visits.

## Changes

- `src/app/app.ts` — `getInitialDarkMode()` falls back to `matchMedia` instead of `true`
- `src/index.html` — inline script checks `matchMedia` when no stored preference exists
- `src/app/app.spec.ts` — `window.matchMedia` mocked globally (defaulting to light); two new tests cover the system-dark and system-light no-preference cases

## Test plan

- [ ] With no stored preference: app theme matches the OS dark/light mode setting
- [ ] After manually toggling: stored preference overrides the system setting on next load
- [ ] `npm test` passes (98 tests)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)