### PR TITLE
Feat: multi-org support — search across multiple GitHub organizations

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,13 +7,17 @@
       <!-- Left: title + active connection chip -->
       <div class="flex items-center gap-3 min-w-0">
         <h1 class="font-semibold text-sm text-ink">Renovate Dashboard</h1>
-        @if (organization()) {
+        @if (connections().length > 0) {
           <div class="hidden sm:flex items-center gap-1.5 px-2 py-1 rounded-md bg-ghost border border-edge text-xs text-ink-2 font-mono max-w-xs">
             <!-- GitHub mark -->
             <svg class="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/>
             </svg>
-            <span class="truncate">github.com / {{ organization() }}</span>
+            @if (connections().length === 1) {
+              <span class="truncate">github.com / {{ connections()[0].organization }}</span>
+            } @else {
+              <span class="truncate">github.com · {{ connections().length }} orgs</span>
+            }
           </div>
         }
       </div>
@@ -22,8 +26,7 @@
       <div class="flex items-center gap-2 shrink-0">
         @if (prGroups().length > 0) {
           <app-workflow-summary
-            [organization]="organization()"
-            [token]="token()"
+            [connections]="connections()"
             [refreshTrigger]="workflowRefreshTrigger()">
           </app-workflow-summary>
         }
@@ -70,12 +73,10 @@
 
     <!-- Connection Form -->
     <app-search-form
-      [organization]="organization()"
-      [token]="token()"
+      [connections]="connections()"
       [isLoading]="isLoading()"
       [formValid]="formValid()"
-      (organizationChange)="organization.set($event)"
-      (tokenChange)="token.set($event)"
+      (connectionsChange)="onConnectionsChange($event)"
       (searchTriggered)="searchAndProcessPullRequests()">
     </app-search-form>
 
@@ -130,7 +131,7 @@
           <svg class="w-10 h-10 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
           </svg>
-          <p class="text-sm">No open Renovate PRs found for this organization.</p>
+          <p class="text-sm">No open Renovate PRs found for the configured organizations.</p>
         </div>
       }
 

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -523,6 +523,7 @@ describe('App', () => {
       return {
         get: vi.fn((key: string) => key === 'organization' ? orgValue : tokenValue),
         set: vi.fn(),
+        remove: vi.fn(),
         getJson: vi.fn((key: string) => key === 'connections' ? connectionsValue : null),
         setJson: vi.fn(),
       };
@@ -546,6 +547,16 @@ describe('App', () => {
 
       expect(app.connections()).toEqual([{ organization: 'legacy-org', token: 'legacy-token' }]);
       expect(storageSpy.setJson).toHaveBeenCalledWith('connections', [{ organization: 'legacy-org', token: 'legacy-token' }]);
+    });
+
+    it('clears the legacy organization/token keys after migrating', () => {
+      const storageSpy = makeStorageSpy(null, 'legacy-org', 'legacy-token');
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      TestBed.createComponent(App);
+
+      expect(storageSpy.remove).toHaveBeenCalledWith('organization');
+      expect(storageSpy.remove).toHaveBeenCalledWith('token');
     });
 
     it('persists connections to session storage when onConnectionsChange is called', () => {

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -381,6 +381,25 @@ describe('App', () => {
 
       expect(app.error()).toContain('everything is down');
     });
+
+    it('sanitizes connections before searching, skipping malformed entries', async () => {
+      const search = {
+        fetchAllSearchItems: vi.fn().mockResolvedValue({ items: [], incompleteResults: false }),
+      };
+      TestBed.overrideProvider(GitHubSearchService, { useValue: search });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      // A malformed entry (empty token) slips into the signal directly.
+      app.connections.set([
+        { organization: 'good-org', token: 'ghp_good' },
+        { organization: 'bad-org', token: '' },
+      ]);
+
+      await app.searchAndProcessPullRequests();
+
+      expect(search.fetchAllSearchItems).toHaveBeenCalledTimes(1);
+      expect(search.fetchAllSearchItems).toHaveBeenCalledWith(expect.stringContaining('org:good-org'), 'ghp_good');
+    });
   });
 
   describe('apiRequest error handling', () => {

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -8,7 +8,7 @@ import { SessionStorageService } from './services/session-storage.service';
 
 interface AppPrivate {
   determineMergeMethod(pr: PullRequest): string;
-  apiRequest<T>(url: string, method?: string, body?: object): Promise<T>;
+  apiRequest<T>(url: string, token: string, method?: string, body?: object): Promise<T>;
 }
 
 function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
@@ -28,6 +28,7 @@ function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
     checkRuns: [],
     isProcessing: false,
     workflowStatus: 'unknown',
+    orgToken: 'ghp_test',
     ...overrides,
   };
 }
@@ -104,34 +105,24 @@ describe('App', () => {
   });
 
   describe('formValid', () => {
-    it('is false when both fields are empty', () => {
+    it('is false when no connections are configured', () => {
       const app = TestBed.createComponent(App).componentInstance;
+      app.connections.set([]);
       expect(app.formValid()).toBe(false);
     });
 
-    it('is false when only organization is set', () => {
+    it('is true when at least one connection is configured', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.organization.set('my-org');
-      expect(app.formValid()).toBe(false);
+      app.connections.set([{ organization: 'my-org', token: 'ghp_token' }]);
+      expect(app.formValid()).toBe(true);
     });
 
-    it('is false when only token is set', () => {
+    it('is true when multiple connections are configured', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.token.set('ghp_token');
-      expect(app.formValid()).toBe(false);
-    });
-
-    it('is false when fields are only whitespace', () => {
-      const app = TestBed.createComponent(App).componentInstance;
-      app.organization.set('   ');
-      app.token.set('   ');
-      expect(app.formValid()).toBe(false);
-    });
-
-    it('is true when both organization and token are non-empty', () => {
-      const app = TestBed.createComponent(App).componentInstance;
-      app.organization.set('my-org');
-      app.token.set('ghp_token');
+      app.connections.set([
+        { organization: 'org-a', token: 'ghp_aaa' },
+        { organization: 'org-b', token: 'ghp_bbb' },
+      ]);
       expect(app.formValid()).toBe(true);
     });
   });
@@ -291,8 +282,6 @@ describe('App', () => {
   describe('approveAndMergeGroupPullRequests', () => {
     it('skips PRs with failing workflows and merges the rest', async () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.organization.set('test-org');
-      app.token.set('ghp_test');
 
       const failingPr = makePr({ id: 1, number: 10, workflowStatus: 'failure' });
       const goodPr = makePr({ id: 2, number: 11, workflowStatus: 'success', commits: 1, allowRebaseMerge: true });
@@ -333,8 +322,7 @@ describe('App', () => {
   describe('fetchAllSearchItems / pagination', () => {
     it('surfaces incompleteResults warning signal after searchAndProcessPullRequests', async () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.organization.set('my-org');
-      app.token.set('ghp_test');
+      app.connections.set([{ organization: 'my-org', token: 'ghp_test' }]);
 
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         new Response(JSON.stringify({ total_count: 1, incomplete_results: true, items: [] }), { status: 200 })
@@ -349,35 +337,32 @@ describe('App', () => {
   describe('apiRequest error handling', () => {
     it('throws with the API error message on non-ok response', async () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.token.set('ghp_test');
 
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         new Response(JSON.stringify({ message: 'Bad credentials' }), { status: 401 })
       );
 
-      await expect((app as unknown as AppPrivate).apiRequest('https://api.github.com/test')).rejects.toThrow('Bad credentials');
+      await expect((app as unknown as AppPrivate).apiRequest('https://api.github.com/test', 'ghp_test')).rejects.toThrow('Bad credentials');
     });
 
     it('falls back to status message when error body is not JSON', async () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.token.set('ghp_test');
 
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         new Response('<html>Bad Gateway</html>', { status: 502, statusText: 'Bad Gateway' })
       );
 
-      await expect((app as unknown as AppPrivate).apiRequest('https://api.github.com/test')).rejects.toThrow('API request failed with status: 502 Bad Gateway');
+      await expect((app as unknown as AppPrivate).apiRequest('https://api.github.com/test', 'ghp_test')).rejects.toThrow('API request failed with status: 502 Bad Gateway');
     });
 
     it('returns undefined for 204 No Content responses', async () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.token.set('ghp_test');
 
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         new Response(null, { status: 204 })
       );
 
-      const result = await (app as unknown as AppPrivate).apiRequest('https://api.github.com/test', 'PUT');
+      const result = await (app as unknown as AppPrivate).apiRequest('https://api.github.com/test', 'ghp_test', 'PUT');
       expect(result).toBeUndefined();
     });
   });
@@ -386,8 +371,6 @@ describe('App', () => {
     it('renders the warning banner when incompleteResults is true', async () => {
       const fixture = TestBed.createComponent(App);
       const app = fixture.componentInstance;
-      app.organization.set('my-org');
-      app.token.set('ghp_test');
       app.incompleteResults.set(true);
       fixture.detectChanges();
 
@@ -454,18 +437,28 @@ describe('App', () => {
   });
 
   describe('top bar', () => {
-    it('shows the connection chip when an organization is set', () => {
+    it('shows org name in chip for a single connection', () => {
       const fixture = TestBed.createComponent(App);
-      fixture.componentInstance.organization.set('my-org');
+      fixture.componentInstance.connections.set([{ organization: 'my-org', token: 'ghp_test' }]);
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toContain('github.com / my-org');
     });
 
-    it('hides the connection chip when no organization is set', () => {
+    it('shows org count in chip for multiple connections', () => {
       const fixture = TestBed.createComponent(App);
-      fixture.componentInstance.organization.set('');
+      fixture.componentInstance.connections.set([
+        { organization: 'org-a', token: 'ghp_aaa' },
+        { organization: 'org-b', token: 'ghp_bbb' },
+      ]);
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).not.toContain('github.com /');
+      expect(fixture.nativeElement.textContent).toContain('github.com · 2 orgs');
+    });
+
+    it('hides the connection chip when no connections are configured', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.componentInstance.connections.set([]);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).not.toContain('github.com');
     });
 
     it('renders the theme toggle button with an accessible label', () => {
@@ -477,52 +470,44 @@ describe('App', () => {
   });
 
   describe('sessionStorage persistence', () => {
-    it('restores organization and token from session storage on init', () => {
-      const storageSpy = { get: vi.fn((key: string) => key === 'organization' ? 'saved-org' : 'saved-token'), set: vi.fn() };
+    function makeStorageSpy(connectionsValue: unknown = null, orgValue = '', tokenValue = '') {
+      return {
+        get: vi.fn((key: string) => key === 'organization' ? orgValue : tokenValue),
+        set: vi.fn(),
+        getJson: vi.fn((key: string) => key === 'connections' ? connectionsValue : null),
+        setJson: vi.fn(),
+      };
+    }
+
+    it('restores connections from session storage on init', () => {
+      const saved = [{ organization: 'saved-org', token: 'saved-token' }];
+      const storageSpy = makeStorageSpy(saved);
       TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
 
       const app = TestBed.createComponent(App).componentInstance;
 
-      expect(app.organization()).toBe('saved-org');
-      expect(app.token()).toBe('saved-token');
+      expect(app.connections()).toEqual(saved);
     });
 
-    it('persists organization and token to session storage on search', async () => {
-      const storageSpy = { get: vi.fn(() => ''), set: vi.fn() };
+    it('migrates old organization/token keys to connections on first load', () => {
+      const storageSpy = makeStorageSpy(null, 'legacy-org', 'legacy-token');
       TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
 
       const app = TestBed.createComponent(App).componentInstance;
-      app.organization.set('my-org');
-      app.token.set('ghp_test');
 
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify({ total_count: 0, incomplete_results: false, items: [] }), { status: 200 })
-      );
-
-      await app.searchAndProcessPullRequests();
-
-      expect(storageSpy.set).toHaveBeenCalledWith('organization', 'my-org');
-      expect(storageSpy.set).toHaveBeenCalledWith('token', 'ghp_test');
+      expect(app.connections()).toEqual([{ organization: 'legacy-org', token: 'legacy-token' }]);
+      expect(storageSpy.setJson).toHaveBeenCalledWith('connections', [{ organization: 'legacy-org', token: 'legacy-token' }]);
     });
 
-    it('trims whitespace from organization and token before persisting and searching', async () => {
-      const storageSpy = { get: vi.fn(() => ''), set: vi.fn() };
+    it('persists connections to session storage when onConnectionsChange is called', () => {
+      const storageSpy = makeStorageSpy();
       TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
 
       const app = TestBed.createComponent(App).componentInstance;
-      app.organization.set('  my-org  ');
-      app.token.set('  ghp_test  ');
+      const newConnections = [{ organization: 'my-org', token: 'ghp_test' }];
+      app.onConnectionsChange(newConnections);
 
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response(JSON.stringify({ total_count: 0, incomplete_results: false, items: [] }), { status: 200 })
-      );
-
-      await app.searchAndProcessPullRequests();
-
-      expect(app.organization()).toBe('my-org');
-      expect(app.token()).toBe('ghp_test');
-      expect(storageSpy.set).toHaveBeenCalledWith('organization', 'my-org');
-      expect(storageSpy.set).toHaveBeenCalledWith('token', 'ghp_test');
+      expect(storageSpy.setJson).toHaveBeenCalledWith('connections', newConnections);
     });
   });
 });

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -5,6 +5,7 @@ import { App } from './app';
 import { getSourceRepositoryUrl } from './config/source-repository-url';
 import { PullRequest, PrGroup } from './models/pull-request.model';
 import { SessionStorageService } from './services/session-storage.service';
+import { GitHubSearchService } from './services/github-search.service';
 
 interface AppPrivate {
   determineMergeMethod(pr: PullRequest): string;
@@ -124,6 +125,18 @@ describe('App', () => {
         { organization: 'org-b', token: 'ghp_bbb' },
       ]);
       expect(app.formValid()).toBe(true);
+    });
+
+    it('is false when the only connection has an empty token', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      app.connections.set([{ organization: 'my-org', token: '' }]);
+      expect(app.formValid()).toBe(false);
+    });
+
+    it('is false when the only connection has a whitespace-only org', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      app.connections.set([{ organization: '   ', token: 'ghp_token' }]);
+      expect(app.formValid()).toBe(false);
     });
   });
 
@@ -334,6 +347,42 @@ describe('App', () => {
     });
   });
 
+  describe('searchAndProcessPullRequests — multi-org partial failure', () => {
+    it('flags incomplete (not error) when one org fails but another succeeds', async () => {
+      const search = {
+        fetchAllSearchItems: vi.fn()
+          .mockResolvedValueOnce({ items: [], incompleteResults: false }) // org-a succeeds
+          .mockRejectedValueOnce(new Error('org-b is down')),             // org-b fails
+      };
+      TestBed.overrideProvider(GitHubSearchService, { useValue: search });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      app.connections.set([
+        { organization: 'org-a', token: 'a' },
+        { organization: 'org-b', token: 'b' },
+      ]);
+
+      await app.searchAndProcessPullRequests();
+
+      expect(app.incompleteResults()).toBe(true);
+      expect(app.error()).toBeNull();
+    });
+
+    it('surfaces an error when every org fails', async () => {
+      const search = {
+        fetchAllSearchItems: vi.fn().mockRejectedValue(new Error('everything is down')),
+      };
+      TestBed.overrideProvider(GitHubSearchService, { useValue: search });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      app.connections.set([{ organization: 'org-a', token: 'a' }]);
+
+      await app.searchAndProcessPullRequests();
+
+      expect(app.error()).toContain('everything is down');
+    });
+  });
+
   describe('apiRequest error handling', () => {
     it('throws with the API error message on non-ok response', async () => {
       const app = TestBed.createComponent(App).componentInstance;
@@ -508,6 +557,55 @@ describe('App', () => {
       app.onConnectionsChange(newConnections);
 
       expect(storageSpy.setJson).toHaveBeenCalledWith('connections', newConnections);
+    });
+
+    it('treats a stored empty array as authoritative and does not re-migrate legacy keys', () => {
+      // User removed all orgs (connections = []) but legacy keys still linger.
+      const storageSpy = makeStorageSpy([], 'legacy-org', 'legacy-token');
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      expect(app.connections()).toEqual([]);
+      expect(storageSpy.setJson).not.toHaveBeenCalled();
+    });
+
+    it('does not migrate when only one legacy key is present', () => {
+      const storageSpy = makeStorageSpy(null, 'legacy-org', ''); // org but no token
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      expect(app.connections()).toEqual([]);
+      expect(storageSpy.setJson).not.toHaveBeenCalled();
+    });
+
+    it('sanitizes stored connections: trims, drops invalid entries, and de-duplicates by org', () => {
+      const storageSpy = makeStorageSpy([
+        { organization: '  org-a  ', token: '  t1  ' },
+        { organization: 'ORG-A', token: 't2' }, // case-insensitive duplicate
+        { organization: '', token: 'no-org' },   // invalid: empty org
+        { organization: 'org-b', token: '' },     // invalid: empty token
+      ]);
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      expect(app.connections()).toEqual([{ organization: 'org-a', token: 't1' }]);
+    });
+
+    it('sanitizes connections passed to onConnectionsChange before storing', () => {
+      const storageSpy = makeStorageSpy();
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      app.onConnectionsChange([
+        { organization: ' my-org ', token: ' ghp_test ' },
+        { organization: 'my-org', token: 'dupe' },
+      ]);
+
+      expect(app.connections()).toEqual([{ organization: 'my-org', token: 'ghp_test' }]);
+      expect(storageSpy.setJson).toHaveBeenCalledWith('connections', [{ organization: 'my-org', token: 'ghp_test' }]);
     });
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -84,6 +84,9 @@ export class App {
     if (org && token) {
       const migrated: OrgConnection[] = [{ organization: org, token }];
       this.storage.setJson(SESSION_KEYS.connections, migrated);
+      // Drop the now-migrated legacy keys so they don't linger for the session.
+      this.storage.remove(SESSION_KEYS.organization);
+      this.storage.remove(SESSION_KEYS.token);
       return migrated;
     }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, signal, computed, inject, effect } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import {
+  OrgConnection,
   PrGroup,
   PullRequest,
   GitHubCheckRunsResponse,
@@ -30,8 +31,7 @@ export class App {
   private doc = inject(DOCUMENT);
 
   // --- STATE SIGNALS ---
-  organization = signal<string>(this.storage.get(SESSION_KEYS.organization));
-  token = signal<string>(this.storage.get(SESSION_KEYS.token));
+  connections = signal<OrgConnection[]>(this.loadConnections());
   darkMode = signal<boolean>(this.getInitialDarkMode());
   prGroups = signal<PrGroup[]>([]);
   isLoading = signal<boolean>(false);
@@ -42,7 +42,7 @@ export class App {
   expandedPrIds = signal<Set<number>>(new Set());
 
   // --- COMPUTED SIGNALS ---
-  formValid = computed(() => this.organization().trim() !== '' && this.token().trim() !== '');
+  formValid = computed(() => this.connections().length > 0);
 
   constructor() {
     effect(() => {
@@ -53,6 +53,34 @@ export class App {
       }
     });
   }
+
+  // --- CONNECTION MANAGEMENT ---
+
+  onConnectionsChange(connections: OrgConnection[]): void {
+    this.connections.set(connections);
+    this.storage.setJson(SESSION_KEYS.connections, connections);
+  }
+
+  private loadConnections(): OrgConnection[] {
+    // If the new connections key exists, use it directly
+    const stored = this.storage.getJson<OrgConnection[]>(SESSION_KEYS.connections);
+    if (Array.isArray(stored) && stored.length > 0) {
+      return stored;
+    }
+
+    // Migrate from old single-org keys
+    const org = this.storage.get(SESSION_KEYS.organization);
+    const token = this.storage.get(SESSION_KEYS.token);
+    if (org || token) {
+      const migrated: OrgConnection[] = [{ organization: org, token }];
+      this.storage.setJson(SESSION_KEYS.connections, migrated);
+      return migrated;
+    }
+
+    return [];
+  }
+
+  // --- DARK MODE ---
 
   private getInitialDarkMode(): boolean {
     try {
@@ -78,7 +106,7 @@ export class App {
   // --- API ORCHESTRATION ---
   async searchAndProcessPullRequests() {
     if (!this.formValid()) {
-      this.error.set("Organization and Personal Access Token are required.");
+      this.error.set("At least one organization connection is required.");
       return;
     }
     this.isLoading.set(true);
@@ -86,31 +114,40 @@ export class App {
     this.prGroups.set([]);
     this.incompleteResults.set(false);
     this.searched.set(true);
-    const orgVal = this.organization().trim();
-    const tokenVal = this.token().trim();
-    this.organization.set(orgVal);
-    this.token.set(tokenVal);
-    this.storage.set(SESSION_KEYS.organization, orgVal);
-    this.storage.set(SESSION_KEYS.token, tokenVal);
+
+    const connections = this.connections();
 
     try {
-      // Step 1: Search for all open PRs by Renovate in the org (auto-paginated)
-      const { items, incompleteResults } = await this.githubSearch.fetchAllSearchItems(
-        `is:pr author:app/renovate org:${orgVal} is:open`,
-        tokenVal
+      // Step 1: Search for all open Renovate PRs across all configured orgs in parallel
+      const searchResults = await Promise.all(
+        connections.map(conn =>
+          this.githubSearch.fetchAllSearchItems(
+            `is:pr author:app/renovate org:${conn.organization} is:open`,
+            conn.token
+          )
+        )
       );
-      this.incompleteResults.set(incompleteResults);
 
-      if (items.length === 0) {
+      // Merge results from all orgs
+      const allItems: GitHubIssueSearchItem[] = [];
+      let anyIncomplete = false;
+      for (const { items, incompleteResults } of searchResults) {
+        allItems.push(...items);
+        if (incompleteResults) anyIncomplete = true;
+      }
+      this.incompleteResults.set(anyIncomplete);
+
+      if (allItems.length === 0) {
         this.prGroups.set([]);
         return;
       }
 
-      const searchResult = { items };
+      // Build a lookup map from org name → token for PR construction
+      const tokenByOrg = new Map(connections.map(c => [c.organization.toLowerCase(), c.token]));
 
       // Step 2: Group PRs by title
       const groupsMap = new Map<string, PrGroup>();
-      searchResult.items.forEach((item: GitHubIssueSearchItem) => {
+      allItems.forEach((item: GitHubIssueSearchItem) => {
         const repoUrlParts = item.repository_url.split('/');
         const repoName = repoUrlParts.pop();
         const repoOwner = repoUrlParts.pop();
@@ -118,6 +155,8 @@ export class App {
         if (!repoOwner || !repoName) {
           return;
         }
+
+        const orgToken = tokenByOrg.get(repoOwner.toLowerCase()) ?? '';
 
         const pr: PullRequest = {
           id: item.id,
@@ -135,13 +174,14 @@ export class App {
           checkRuns: [], // Initialize as empty
           isProcessing: false,
           workflowStatus: 'unknown', // Default
+          orgToken,
         };
-        
+
         if (!groupsMap.has(pr.title)) {
-          groupsMap.set(pr.title, { 
-            title: pr.title, 
-            prs: [], 
-            aggregateCiStatus: 'unknown', 
+          groupsMap.set(pr.title, {
+            title: pr.title,
+            prs: [],
+            aggregateCiStatus: 'unknown',
             isExpanded: false,
             workflowSummary: { success: 0, pending: 0, failed: 0 }
           });
@@ -164,7 +204,7 @@ export class App {
 
       this.prGroups.set(Array.from(groupsMap.values()));
       this.expandedPrIds.set(new Set());
-      
+
       // Trigger workflow summary refresh
       this.bumpWorkflowSummaryRefresh();
 
@@ -182,26 +222,26 @@ export class App {
     try {
       // Get full PR data (for commit count and head SHA)
       const prUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}`;
-      const prData = await this.apiRequest<GitHubPullRequestDetails>(prUrl);
+      const prData = await this.apiRequest<GitHubPullRequestDetails>(prUrl, pr.orgToken);
       pr.isModified = prData.commits > 1;
       pr.head.sha = prData.head.sha;
       pr.commits = prData.commits;
 
       // Get repository settings to determine allowed merge methods
       const repoUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}`;
-      const repoData = await this.apiRequest<GitHubRepository>(repoUrl);
+      const repoData = await this.apiRequest<GitHubRepository>(repoUrl, pr.orgToken);
       pr.allowSquashMerge = repoData.allow_squash_merge;
       pr.allowMergeCommit = repoData.allow_merge_commit;
       pr.allowRebaseMerge = repoData.allow_rebase_merge;
 
       // Get combined CI status for the PR's head commit (as a fallback)
       const statusUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/status`;
-      const statusData = await this.apiRequest<GitHubCombinedStatusResponse>(statusUrl);
+      const statusData = await this.apiRequest<GitHubCombinedStatusResponse>(statusUrl, pr.orgToken);
       pr.ciStatus = this.mapCombinedStatus(statusData.state);
 
       // Get individual check runs for more detailed status
       const checksUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/check-runs`;
-      const checksData = await this.apiRequest<GitHubCheckRunsResponse>(checksUrl);
+      const checksData = await this.apiRequest<GitHubCheckRunsResponse>(checksUrl, pr.orgToken);
       if (checksData && checksData.check_runs) {
         pr.checkRuns = checksData.check_runs.map(cr => ({
           id: cr.id,
@@ -244,7 +284,7 @@ export class App {
     this.setPrProcessingState(prToUpdate, true);
     try {
       const url = `https://api.github.com/repos/${prToUpdate.repoOwner}/${prToUpdate.repoName}/pulls/${prToUpdate.number}`;
-      await this.apiRequest<void>(url, 'PATCH', { state: 'closed' });
+      await this.apiRequest<void>(url, prToUpdate.orgToken, 'PATCH', { state: 'closed' });
       // Remove PR from UI
       this.removePrFromGroup(prToUpdate);
       if (refreshSummary) {
@@ -267,15 +307,15 @@ export class App {
 
       // Step 1: Approve
       const reviewUrl = `https://api.github.com/repos/${prToUpdate.repoOwner}/${prToUpdate.repoName}/pulls/${prToUpdate.number}/reviews`;
-      await this.apiRequest<void>(reviewUrl, 'POST', { event: 'APPROVE' });
+      await this.apiRequest<void>(reviewUrl, prToUpdate.orgToken, 'POST', { event: 'APPROVE' });
 
       // Step 2: Determine merge method
       const mergeMethod = this.determineMergeMethod(prToUpdate);
 
       // Step 3: Merge with the appropriate method
       const mergeUrl = `https://api.github.com/repos/${prToUpdate.repoOwner}/${prToUpdate.repoName}/pulls/${prToUpdate.number}/merge`;
-      await this.apiRequest<void>(mergeUrl, 'PUT', { merge_method: mergeMethod });
-      
+      await this.apiRequest<void>(mergeUrl, prToUpdate.orgToken, 'PUT', { merge_method: mergeMethod });
+
       // Remove PR from UI
       this.removePrFromGroup(prToUpdate);
       if (refreshSummary) {
@@ -324,10 +364,10 @@ export class App {
 
   // --- HELPER & UTILITY METHODS ---
 
-  private async apiRequest<T>(url: string, method = 'GET', body?: object): Promise<T> {
+  private async apiRequest<T>(url: string, token: string, method = 'GET', body?: object): Promise<T> {
     const headers: HeadersInit = {
       'Accept': 'application/vnd.github.v3+json',
-      'Authorization': `token ${this.token()}`
+      'Authorization': `token ${token}`
     };
     const options: RequestInit = { method, headers };
     if (body) {
@@ -426,7 +466,7 @@ export class App {
 
     return { success, pending, failed };
   }
- 
+
   private mapCombinedStatus(state: GitHubCombinedStatusResponse['state'] | null | undefined): CiStatus {
     switch (state) {
       case 'success':
@@ -443,22 +483,22 @@ export class App {
 
   private determineMergeMethod(pr: PullRequest): string {
     const commits = pr.commits ?? 0;
-    
+
     // If only one commit and rebase is supported, use rebase
     if (commits === 1 && pr.allowRebaseMerge) {
       return 'rebase';
     }
-    
+
     // If more than one commit and squash is supported, use squash
     if (commits > 1 && pr.allowSquashMerge) {
       return 'squash';
     }
-    
+
     // Otherwise if merge is supported, use merge
     if (pr.allowMergeCommit) {
       return 'merge';
     }
-    
+
     // If none of those work, throw an error
     throw new Error(`No suitable merge method available for PR #${pr.number}`);
   }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -42,7 +42,12 @@ export class App {
   expandedPrIds = signal<Set<number>>(new Set());
 
   // --- COMPUTED SIGNALS ---
-  formValid = computed(() => this.connections().length > 0);
+  // Valid only when at least one connection has both an org and a token, so a
+  // malformed entry (e.g. from a partial legacy migration) can't enable a search
+  // that would fail with an empty token.
+  formValid = computed(() =>
+    this.connections().some(c => c.organization.trim().length > 0 && c.token.trim().length > 0),
+  );
 
   constructor() {
     effect(() => {
@@ -57,27 +62,52 @@ export class App {
   // --- CONNECTION MANAGEMENT ---
 
   onConnectionsChange(connections: OrgConnection[]): void {
-    this.connections.set(connections);
-    this.storage.setJson(SESSION_KEYS.connections, connections);
+    const sanitized = this.sanitizeConnections(connections);
+    this.connections.set(sanitized);
+    this.storage.setJson(SESSION_KEYS.connections, sanitized);
   }
 
   private loadConnections(): OrgConnection[] {
-    // If the new connections key exists, use it directly
+    // The new connections key is authoritative once present — even an empty
+    // array means "the user has no orgs configured", so we must not fall back
+    // to migrating legacy keys (that would repopulate after removing all orgs).
     const stored = this.storage.getJson<OrgConnection[]>(SESSION_KEYS.connections);
-    if (Array.isArray(stored) && stored.length > 0) {
-      return stored;
+    if (Array.isArray(stored)) {
+      return this.sanitizeConnections(stored);
     }
 
-    // Migrate from old single-org keys
-    const org = this.storage.get(SESSION_KEYS.organization);
-    const token = this.storage.get(SESSION_KEYS.token);
-    if (org || token) {
+    // Migrate from old single-org keys only when the new key is absent, and
+    // only when both legacy values are non-empty after trimming (a lone org or
+    // token can't make a valid connection).
+    const org = this.storage.get(SESSION_KEYS.organization).trim();
+    const token = this.storage.get(SESSION_KEYS.token).trim();
+    if (org && token) {
       const migrated: OrgConnection[] = [{ organization: org, token }];
       this.storage.setJson(SESSION_KEYS.connections, migrated);
       return migrated;
     }
 
     return [];
+  }
+
+  /** Trim, drop entries missing an org or token, and de-duplicate by org (case-insensitive). */
+  private sanitizeConnections(connections: OrgConnection[]): OrgConnection[] {
+    const seen = new Set<string>();
+    const result: OrgConnection[] = [];
+    for (const c of connections) {
+      if (!c || typeof c.organization !== 'string' || typeof c.token !== 'string') {
+        continue;
+      }
+      const organization = c.organization.trim();
+      const token = c.token.trim();
+      const key = organization.toLowerCase();
+      if (!organization || !token || seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      result.push({ organization, token });
+    }
+    return result;
   }
 
   // --- DARK MODE ---
@@ -118,8 +148,10 @@ export class App {
     const connections = this.connections();
 
     try {
-      // Step 1: Search for all open Renovate PRs across all configured orgs in parallel
-      const searchResults = await Promise.all(
+      // Step 1: Search for all open Renovate PRs across all configured orgs in
+      // parallel. Use allSettled so one org's failure doesn't discard the others'
+      // results — merge what succeeded and flag the rest as incomplete.
+      const searchResults = await Promise.allSettled(
         connections.map(conn =>
           this.githubSearch.fetchAllSearchItems(
             `is:pr author:app/renovate org:${conn.organization} is:open`,
@@ -128,12 +160,25 @@ export class App {
         )
       );
 
-      // Merge results from all orgs
+      // If every org failed, surface the error rather than a misleading empty state.
+      const firstRejection = searchResults.find(r => r.status === 'rejected');
+      if (firstRejection?.status === 'rejected' && !searchResults.some(r => r.status === 'fulfilled')) {
+        throw firstRejection.reason instanceof Error
+          ? firstRejection.reason
+          : new Error('Search failed for all configured organizations.');
+      }
+
+      // Merge results from all orgs; a rejected org counts as incomplete.
       const allItems: GitHubIssueSearchItem[] = [];
       let anyIncomplete = false;
-      for (const { items, incompleteResults } of searchResults) {
-        allItems.push(...items);
-        if (incompleteResults) anyIncomplete = true;
+      for (const result of searchResults) {
+        if (result.status === 'fulfilled') {
+          allItems.push(...result.value.items);
+          if (result.value.incompleteResults) anyIncomplete = true;
+        } else {
+          anyIncomplete = true;
+          console.error('Renovate PR search failed for one organization', result.reason);
+        }
       }
       this.incompleteResults.set(anyIncomplete);
 
@@ -156,7 +201,13 @@ export class App {
           return;
         }
 
-        const orgToken = tokenByOrg.get(repoOwner.toLowerCase()) ?? '';
+        // Every returned PR should belong to a configured org, but guard against
+        // an unexpected owner rather than issuing an API call with an empty token.
+        const orgToken = tokenByOrg.get(repoOwner.toLowerCase());
+        if (!orgToken) {
+          console.warn(`No configured token for "${repoOwner}"; skipping PR #${item.number}`);
+          return;
+        }
 
         const pr: PullRequest = {
           id: item.id,

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -42,9 +42,9 @@ export class App {
   expandedPrIds = signal<Set<number>>(new Set());
 
   // --- COMPUTED SIGNALS ---
-  // Valid only when at least one connection has both an org and a token, so a
-  // malformed entry (e.g. from a partial legacy migration) can't enable a search
-  // that would fail with an empty token.
+  // Enabled when at least one connection is usable (both fields non-empty).
+  // searchAndProcessPullRequests() sanitizes again before searching, so any
+  // malformed entries are skipped rather than issuing an empty-token request.
   formValid = computed(() =>
     this.connections().some(c => c.organization.trim().length > 0 && c.token.trim().length > 0),
   );
@@ -148,7 +148,10 @@ export class App {
     this.incompleteResults.set(false);
     this.searched.set(true);
 
-    const connections = this.connections();
+    // Sanitize again here so the search never issues a request for a malformed
+    // connection, regardless of how connections() was populated. formValid()
+    // guarantees at least one survives.
+    const connections = this.sanitizeConnections(this.connections());
 
     try {
       // Step 1: Search for all open Renovate PRs across all configured orgs in

--- a/src/app/components/pr-group/pr-group.component.spec.ts
+++ b/src/app/components/pr-group/pr-group.component.spec.ts
@@ -25,6 +25,7 @@ function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
     checkRuns: [],
     isProcessing: false,
     workflowStatus: 'unknown',
+    orgToken: 'ghp_test',
     ...overrides,
   };
 }

--- a/src/app/components/pr-item/pr-item.component.spec.ts
+++ b/src/app/components/pr-item/pr-item.component.spec.ts
@@ -25,6 +25,7 @@ function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
     checkRuns: [],
     isProcessing: false,
     workflowStatus: 'unknown',
+    orgToken: 'ghp_test',
     ...overrides,
   };
 }

--- a/src/app/components/search-form/search-form.component.html
+++ b/src/app/components/search-form/search-form.component.html
@@ -16,59 +16,108 @@
       </div>
     </div>
 
-    <!-- Organization + Token inputs -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <!-- Configured connections list -->
+    @if (connections().length > 0) {
       <div>
-        <div class="flex items-center h-5 mb-2">
-          <label for="organization" class="text-xs font-medium text-ink-2">Organization</label>
-        </div>
-        <input
-          id="organization"
-          type="text"
-          [value]="organization()"
-          (input)="onOrganizationChange($event)"
-          placeholder="e.g., my-github-org"
-          class="w-full bg-ghost border border-edge rounded-md px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:ring-2 focus:ring-accent focus:outline-none transition duration-200"
-        />
-      </div>
-
-      <div>
-        <div class="flex items-center gap-1.5 h-5 mb-2">
-          <label for="token" class="text-xs font-medium text-ink-2">Personal Access Token</label>
-          <div class="relative group">
-            <button
-              type="button"
-              class="text-ink-3 cursor-help rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              aria-label="Token storage info"
-              aria-describedby="token-tooltip"
-            >
-              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <circle cx="12" cy="12" r="10" stroke-width="2"/>
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 16v-4m0-4h.01"/>
+        <span class="block text-xs font-medium text-ink-2 mb-2">Organizations</span>
+        <div class="rounded-md border border-edge overflow-hidden divide-y divide-edge">
+          @for (conn of connections(); track conn.organization) {
+            <div class="flex items-center gap-3 px-3 py-2 bg-ghost">
+              <svg class="w-4 h-4 shrink-0 text-ink-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/>
               </svg>
-            </button>
-            <div
-              id="token-tooltip"
-              role="tooltip"
-              class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 rounded-md bg-panel border border-edge px-3 py-2 text-xs text-ink-2 shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 pointer-events-none transition-opacity duration-150 z-10"
-            >
-              Stored for this session only — cleared when the tab is closed.
+              <span class="flex-1 text-sm text-ink font-mono truncate">{{ conn.organization }}</span>
+              <span class="text-xs text-ink-3 font-mono select-none shrink-0" aria-hidden="true">••••••••</span>
+              <button
+                type="button"
+                (click)="removeConnection(conn.organization)"
+                [attr.aria-label]="'Remove ' + conn.organization"
+                class="p-1 rounded text-ink-3 hover:text-rose-400 hover:bg-rose-500/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+              </button>
+            </div>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Add organization inputs -->
+    <div>
+      <span class="block text-xs font-medium text-ink-2 mb-3">
+        @if (connections().length > 0) { Add organization } @else { Organization }
+      </span>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <div class="flex items-center h-5 mb-2">
+            <label for="draft-org" class="text-xs font-medium text-ink-2">Organization</label>
+          </div>
+          <input
+            id="draft-org"
+            type="text"
+            [value]="draftOrg()"
+            (input)="onDraftOrgChange($event)"
+            (keydown.enter)="onDraftEnter($event)"
+            placeholder="e.g., my-github-org"
+            class="w-full bg-ghost border border-edge rounded-md px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:ring-2 focus:ring-accent focus:outline-none transition duration-200"
+          />
+          @if (isDuplicateOrg()) {
+            <p class="mt-1 text-xs text-amber-400">Already added.</p>
+          }
+        </div>
+
+        <div>
+          <div class="flex items-center gap-1.5 h-5 mb-2">
+            <label for="draft-token" class="text-xs font-medium text-ink-2">Personal Access Token</label>
+            <div class="relative group">
+              <button
+                type="button"
+                class="text-ink-3 cursor-help rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                aria-label="Token storage info"
+                aria-describedby="token-tooltip"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" stroke-width="2"/>
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 16v-4m0-4h.01"/>
+                </svg>
+              </button>
+              <div
+                id="token-tooltip"
+                role="tooltip"
+                class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 rounded-md bg-panel border border-edge px-3 py-2 text-xs text-ink-2 shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 pointer-events-none transition-opacity duration-150 z-10"
+              >
+                Stored for this session only — cleared when the tab is closed.
+              </div>
             </div>
           </div>
+          <input
+            id="draft-token"
+            type="password"
+            [value]="draftToken()"
+            (input)="onDraftTokenChange($event)"
+            (keydown.enter)="onDraftEnter($event)"
+            placeholder="Token with 'repo' scope is required"
+            class="w-full bg-ghost border border-edge rounded-md px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:ring-2 focus:ring-accent focus:outline-none transition duration-200"
+          />
         </div>
-        <input
-          id="token"
-          type="password"
-          [value]="token()"
-          (input)="onTokenChange($event)"
-          placeholder="Token with 'repo' scope is required"
-          class="w-full bg-ghost border border-edge rounded-md px-3 py-2 text-sm text-ink placeholder:text-ink-3 focus:ring-2 focus:ring-accent focus:outline-none transition duration-200"
-        />
+      </div>
+
+      <div class="flex justify-end mt-3">
+        <button
+          type="button"
+          (click)="addConnection()"
+          [disabled]="!draftValid()"
+          class="px-4 py-2 bg-ghost border border-edge text-sm font-medium rounded-md text-ink hover:bg-matte disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-accent transition-colors duration-200"
+        >
+          Add
+        </button>
       </div>
     </div>
 
     <!-- Submit -->
-    <div class="flex justify-end">
+    <div class="flex justify-end border-t border-edge pt-4">
       <button
         type="submit"
         [disabled]="isLoading() || !formValid()"

--- a/src/app/components/search-form/search-form.component.spec.ts
+++ b/src/app/components/search-form/search-form.component.spec.ts
@@ -85,6 +85,16 @@ describe('SearchFormComponent', () => {
       expect(fixture.nativeElement.textContent).toContain('Already added');
     });
 
+    it('detects duplicates case-insensitively (GitHub orgs are case-insensitive)', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', [ORG_A]); // 'org-a'
+      fixture.componentInstance.draftOrg.set('  ORG-A  ');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.isDuplicateOrg()).toBe(true);
+      expect(fixture.componentInstance.draftValid()).toBe(false);
+    });
+
     it('emits connectionsChange with the new connection appended when Add is clicked', () => {
       const fixture = TestBed.createComponent(SearchFormComponent);
       fixture.componentRef.setInput('connections', [ORG_A]);

--- a/src/app/components/search-form/search-form.component.spec.ts
+++ b/src/app/components/search-form/search-form.component.spec.ts
@@ -1,6 +1,10 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { SearchFormComponent } from './search-form.component';
+import { OrgConnection } from '../../models/pull-request.model';
+
+const ORG_A: OrgConnection = { organization: 'org-a', token: 'ghp_aaa' };
+const ORG_B: OrgConnection = { organization: 'org-b', token: 'ghp_bbb' };
 
 describe('SearchFormComponent', () => {
   beforeEach(async () => {
@@ -15,73 +19,159 @@ describe('SearchFormComponent', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('emits organizationChange when the organization input changes', () => {
-    const fixture = TestBed.createComponent(SearchFormComponent);
-    fixture.detectChanges();
-    const emitted: string[] = [];
-    fixture.componentInstance.organizationChange.subscribe((v: string) => emitted.push(v));
+  describe('connections list', () => {
+    it('shows each configured organization', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', [ORG_A, ORG_B]);
+      fixture.detectChanges();
 
-    const input = fixture.nativeElement.querySelector('#organization') as HTMLInputElement;
-    input.value = 'my-org';
-    input.dispatchEvent(new Event('input'));
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain('org-a');
+      expect(text).toContain('org-b');
+    });
 
-    expect(emitted).toEqual(['my-org']);
+    it('hides the list when there are no connections', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', []);
+      fixture.detectChanges();
+
+      const rows = fixture.nativeElement.querySelectorAll('[aria-label^="Remove"]');
+      expect(rows.length).toBe(0);
+    });
+
+    it('emits connectionsChange without the removed org when Remove is clicked', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', [ORG_A, ORG_B]);
+      fixture.detectChanges();
+
+      const emitted: OrgConnection[][] = [];
+      fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) => emitted.push(v));
+
+      const removeBtn = fixture.nativeElement.querySelector('[aria-label="Remove org-a"]') as HTMLButtonElement;
+      removeBtn.click();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual([ORG_B]);
+    });
   });
 
-  it('emits tokenChange when the token input changes', () => {
-    const fixture = TestBed.createComponent(SearchFormComponent);
-    fixture.detectChanges();
-    const emitted: string[] = [];
-    fixture.componentInstance.tokenChange.subscribe((v: string) => emitted.push(v));
+  describe('add connection', () => {
+    it('Add button is disabled when draft fields are empty', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', []);
+      fixture.detectChanges();
 
-    const input = fixture.nativeElement.querySelector('#token') as HTMLInputElement;
-    input.value = 'ghp_secret';
-    input.dispatchEvent(new Event('input'));
+      const addBtn = fixture.nativeElement.querySelector('button[type="button"]:not([aria-label])') as HTMLButtonElement;
+      expect(addBtn.disabled).toBe(true);
+    });
 
-    expect(emitted).toEqual(['ghp_secret']);
+    it('Add button is disabled when the org is already added', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', [ORG_A]);
+      fixture.componentInstance.draftOrg.set('org-a');
+      fixture.componentInstance.draftToken.set('ghp_new');
+      fixture.detectChanges();
+
+      const addBtn = fixture.nativeElement.querySelector('button[type="button"]:not([aria-label])') as HTMLButtonElement;
+      expect(addBtn.disabled).toBe(true);
+    });
+
+    it('shows a duplicate warning when the draft org is already configured', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', [ORG_A]);
+      fixture.componentInstance.draftOrg.set('org-a');
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('Already added');
+    });
+
+    it('emits connectionsChange with the new connection appended when Add is clicked', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', [ORG_A]);
+      fixture.componentInstance.draftOrg.set('org-b');
+      fixture.componentInstance.draftToken.set('ghp_bbb');
+      fixture.detectChanges();
+
+      const emitted: OrgConnection[][] = [];
+      fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) => emitted.push(v));
+
+      const addBtn = fixture.nativeElement.querySelector('button[type="button"]:not([aria-label])') as HTMLButtonElement;
+      addBtn.click();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toEqual([ORG_A, ORG_B]);
+    });
+
+    it('clears the draft fields after a successful add', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', []);
+      fixture.componentInstance.draftOrg.set('org-a');
+      fixture.componentInstance.draftToken.set('ghp_aaa');
+      fixture.componentInstance.connectionsChange.subscribe((conns: OrgConnection[]) => { void conns; });
+
+      fixture.componentInstance.addConnection();
+
+      expect(fixture.componentInstance.draftOrg()).toBe('');
+      expect(fixture.componentInstance.draftToken()).toBe('');
+    });
+
+    it('trims whitespace from draft org and token on add', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('connections', []);
+      fixture.componentInstance.draftOrg.set('  org-a  ');
+      fixture.componentInstance.draftToken.set('  ghp_aaa  ');
+
+      const emitted: OrgConnection[][] = [];
+      fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) => emitted.push(v));
+
+      fixture.componentInstance.addConnection();
+
+      expect(emitted[0]).toEqual([{ organization: 'org-a', token: 'ghp_aaa' }]);
+    });
   });
 
-  it('emits searchTriggered when the form is submitted', () => {
-    const fixture = TestBed.createComponent(SearchFormComponent);
-    fixture.componentRef.setInput('formValid', true);
-    fixture.detectChanges();
+  describe('submit button', () => {
+    it('is disabled when formValid is false', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('formValid', false);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
 
-    let emitted = false;
-    fixture.componentInstance.searchTriggered.subscribe(() => { emitted = true; });
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
 
-    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
-    form.dispatchEvent(new Event('submit'));
+    it('is disabled while loading', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('formValid', true);
+      fixture.componentRef.setInput('isLoading', true);
+      fixture.detectChanges();
 
-    expect(emitted).toBe(true);
-  });
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
 
-  it('disables the submit button when the form is not valid', () => {
-    const fixture = TestBed.createComponent(SearchFormComponent);
-    fixture.componentRef.setInput('formValid', false);
-    fixture.componentRef.setInput('isLoading', false);
-    fixture.detectChanges();
+    it('is enabled when valid and not loading', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('formValid', true);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
 
-    const button = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
-  });
+      const btn = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
 
-  it('disables the submit button while loading', () => {
-    const fixture = TestBed.createComponent(SearchFormComponent);
-    fixture.componentRef.setInput('formValid', true);
-    fixture.componentRef.setInput('isLoading', true);
-    fixture.detectChanges();
+    it('emits searchTriggered when the form is submitted', () => {
+      const fixture = TestBed.createComponent(SearchFormComponent);
+      fixture.componentRef.setInput('formValid', true);
+      fixture.detectChanges();
 
-    const button = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
-  });
+      let emitted = false;
+      fixture.componentInstance.searchTriggered.subscribe(() => { emitted = true; });
 
-  it('enables the submit button when valid and not loading', () => {
-    const fixture = TestBed.createComponent(SearchFormComponent);
-    fixture.componentRef.setInput('formValid', true);
-    fixture.componentRef.setInput('isLoading', false);
-    fixture.detectChanges();
+      fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
 
-    const button = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(button.disabled).toBe(false);
+      expect(emitted).toBe(true);
+    });
   });
 });

--- a/src/app/components/search-form/search-form.component.ts
+++ b/src/app/components/search-form/search-form.component.ts
@@ -20,8 +20,10 @@ export class SearchFormComponent {
   draftToken = signal('');
 
   isDuplicateOrg = computed(() => {
-    const org = this.draftOrg().trim();
-    return org.length > 0 && this.connections().some(c => c.organization === org);
+    // GitHub org names are case-insensitive, so compare normalized values while
+    // preserving the user's typed casing for display.
+    const org = this.draftOrg().trim().toLowerCase();
+    return org.length > 0 && this.connections().some(c => c.organization.trim().toLowerCase() === org);
   });
 
   draftValid = computed(() => {

--- a/src/app/components/search-form/search-form.component.ts
+++ b/src/app/components/search-form/search-form.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { OrgConnection } from '../../models/pull-request.model';
 
 @Component({
   selector: 'app-search-form',
@@ -8,23 +9,52 @@ import { ChangeDetectionStrategy, Component, input, output } from '@angular/core
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchFormComponent {
-  organization = input('');
-  token = input('');
+  connections = input<OrgConnection[]>([]);
   isLoading = input(false);
   formValid = input(false);
 
-  organizationChange = output<string>();
-  tokenChange = output<string>();
+  connectionsChange = output<OrgConnection[]>();
   searchTriggered = output<void>();
 
-  onOrganizationChange(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    this.organizationChange.emit(target.value);
+  draftOrg = signal('');
+  draftToken = signal('');
+
+  isDuplicateOrg = computed(() => {
+    const org = this.draftOrg().trim();
+    return org.length > 0 && this.connections().some(c => c.organization === org);
+  });
+
+  draftValid = computed(() => {
+    const org = this.draftOrg().trim();
+    const token = this.draftToken().trim();
+    return org.length > 0 && token.length > 0 && !this.isDuplicateOrg();
+  });
+
+  onDraftOrgChange(event: Event): void {
+    this.draftOrg.set((event.target as HTMLInputElement).value);
   }
 
-  onTokenChange(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    this.tokenChange.emit(target.value);
+  onDraftTokenChange(event: Event): void {
+    this.draftToken.set((event.target as HTMLInputElement).value);
+  }
+
+  addConnection(): void {
+    if (!this.draftValid()) return;
+    this.connectionsChange.emit([
+      ...this.connections(),
+      { organization: this.draftOrg().trim(), token: this.draftToken().trim() },
+    ]);
+    this.draftOrg.set('');
+    this.draftToken.set('');
+  }
+
+  removeConnection(organization: string): void {
+    this.connectionsChange.emit(this.connections().filter(c => c.organization !== organization));
+  }
+
+  onDraftEnter(event: Event): void {
+    event.preventDefault();
+    this.addConnection();
   }
 
   onSearch(): void {

--- a/src/app/models/pull-request.model.ts
+++ b/src/app/models/pull-request.model.ts
@@ -1,5 +1,10 @@
 export type CiStatus = 'success' | 'failure' | 'pending' | 'unknown';
 
+export interface OrgConnection {
+  organization: string;
+  token: string;
+}
+
 export interface GitHubUser {
   login: string;
   avatar_url: string;
@@ -76,6 +81,7 @@ export interface PullRequest {
   checkRuns: CheckRun[];
   isProcessing: boolean; // For button loading states
   workflowStatus: CiStatus;
+  orgToken: string; // Token for the org that owns this PR's repository
   commits?: number; // Number of commits in the PR
   allowSquashMerge?: boolean;
   allowMergeCommit?: boolean;

--- a/src/app/services/session-storage.service.ts
+++ b/src/app/services/session-storage.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 export const SESSION_KEYS = {
   organization: 'organization',
   token: 'token',
+  connections: 'connections',
 } as const;
 
 @Injectable({ providedIn: 'root' })
@@ -40,6 +41,29 @@ export class SessionStorageService {
     }
     try {
       sessionStorage.setItem(key, value);
+    } catch {
+      // Swallow errors to keep this a no-op when storage is unavailable.
+    }
+  }
+
+  getJson<T>(key: string): T | null {
+    if (!this.available) {
+      return null;
+    }
+    try {
+      const raw = sessionStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  setJson<T>(key: string, value: T): void {
+    if (!this.available) {
+      return;
+    }
+    try {
+      sessionStorage.setItem(key, JSON.stringify(value));
     } catch {
       // Swallow errors to keep this a no-op when storage is unavailable.
     }

--- a/src/app/services/session-storage.service.ts
+++ b/src/app/services/session-storage.service.ts
@@ -46,6 +46,17 @@ export class SessionStorageService {
     }
   }
 
+  remove(key: string): void {
+    if (!this.available) {
+      return;
+    }
+    try {
+      sessionStorage.removeItem(key);
+    } catch {
+      // Swallow errors to keep this a no-op when storage is unavailable.
+    }
+  }
+
   getJson<T>(key: string): T | null {
     if (!this.available) {
       return null;

--- a/src/app/workflow-summary.component.spec.ts
+++ b/src/app/workflow-summary.component.spec.ts
@@ -3,6 +3,9 @@ import { TestBed } from '@angular/core/testing';
 import { vi } from 'vitest';
 import { WorkflowSummaryComponent } from './workflow-summary.component';
 import { WorkflowSummaryService } from './workflow-summary.service';
+import { OrgConnection } from './models/pull-request.model';
+
+const CONNECTIONS: OrgConnection[] = [{ organization: 'my-org', token: 'ghp_test' }];
 
 describe('WorkflowSummaryComponent', () => {
   let summaryServiceSpy: { getSummary: ReturnType<typeof vi.fn> };
@@ -27,71 +30,50 @@ describe('WorkflowSummaryComponent', () => {
 
   it('does not load when refreshTrigger is 0', async () => {
     const fixture = TestBed.createComponent(WorkflowSummaryComponent);
-    fixture.componentRef.setInput('organization', 'my-org');
-    fixture.componentRef.setInput('token', 'ghp_test');
+    fixture.componentRef.setInput('connections', CONNECTIONS);
     fixture.componentRef.setInput('refreshTrigger', 0);
     TestBed.flushEffects();
 
     expect(summaryServiceSpy.getSummary).not.toHaveBeenCalled();
   });
 
-  it('does not load when organization or token is missing', async () => {
+  it('does not load when connections list is empty', async () => {
     const fixture = TestBed.createComponent(WorkflowSummaryComponent);
-    fixture.componentRef.setInput('organization', '');
-    fixture.componentRef.setInput('token', '');
+    fixture.componentRef.setInput('connections', []);
     fixture.componentRef.setInput('refreshTrigger', 1);
     TestBed.flushEffects();
 
     expect(summaryServiceSpy.getSummary).not.toHaveBeenCalled();
   });
 
-  it('loads summary when organization, token, and refreshTrigger > 0 are provided', async () => {
+  it('loads summary when connections and refreshTrigger > 0 are provided', async () => {
     const fixture = TestBed.createComponent(WorkflowSummaryComponent);
-    fixture.componentRef.setInput('organization', 'my-org');
-    fixture.componentRef.setInput('token', 'ghp_test');
+    fixture.componentRef.setInput('connections', CONNECTIONS);
     fixture.componentRef.setInput('refreshTrigger', 1);
     TestBed.flushEffects();
 
-    expect(summaryServiceSpy.getSummary).toHaveBeenCalledWith('my-org', 'ghp_test');
+    expect(summaryServiceSpy.getSummary).toHaveBeenCalledWith(CONNECTIONS);
   });
 
   it('updates summary signal after successful load', async () => {
     const fixture = TestBed.createComponent(WorkflowSummaryComponent);
-    fixture.componentRef.setInput('organization', 'my-org');
-    fixture.componentRef.setInput('token', 'ghp_test');
+    fixture.componentRef.setInput('connections', CONNECTIONS);
     fixture.componentRef.setInput('refreshTrigger', 1);
     TestBed.flushEffects();
 
-    // Wait for the async getSummary to resolve
     await summaryServiceSpy.getSummary.mock.results[0].value;
 
     expect(fixture.componentInstance.summary()).toEqual({ success: 3, pending: 1, failed: 2 });
   });
 
-  it('does not reload when organization changes without a refreshTrigger bump', () => {
+  it('does not reload when connections change without a refreshTrigger bump', () => {
     const fixture = TestBed.createComponent(WorkflowSummaryComponent);
-    fixture.componentRef.setInput('organization', 'my-org');
-    fixture.componentRef.setInput('token', 'ghp_test');
+    fixture.componentRef.setInput('connections', CONNECTIONS);
     fixture.componentRef.setInput('refreshTrigger', 1);
     TestBed.flushEffects();
     summaryServiceSpy.getSummary.mockClear();
 
-    // Simulate the user editing the organization field without re-submitting
-    fixture.componentRef.setInput('organization', 'my-org-edited');
-    TestBed.flushEffects();
-
-    expect(summaryServiceSpy.getSummary).not.toHaveBeenCalled();
-  });
-
-  it('does not reload when token changes without a refreshTrigger bump', () => {
-    const fixture = TestBed.createComponent(WorkflowSummaryComponent);
-    fixture.componentRef.setInput('organization', 'my-org');
-    fixture.componentRef.setInput('token', 'ghp_test');
-    fixture.componentRef.setInput('refreshTrigger', 1);
-    TestBed.flushEffects();
-    summaryServiceSpy.getSummary.mockClear();
-
-    fixture.componentRef.setInput('token', 'ghp_new_token');
+    fixture.componentRef.setInput('connections', [{ organization: 'other-org', token: 'ghp_other' }]);
     TestBed.flushEffects();
 
     expect(summaryServiceSpy.getSummary).not.toHaveBeenCalled();
@@ -125,8 +107,7 @@ describe('WorkflowSummaryComponent', () => {
     summaryServiceSpy.getSummary.mockRejectedValueOnce(new Error('Network error'));
 
     const fixture = TestBed.createComponent(WorkflowSummaryComponent);
-    fixture.componentRef.setInput('organization', 'my-org');
-    fixture.componentRef.setInput('token', 'ghp_test');
+    fixture.componentRef.setInput('connections', CONNECTIONS);
     fixture.componentRef.setInput('refreshTrigger', 1);
     TestBed.flushEffects();
 

--- a/src/app/workflow-summary.component.spec.ts
+++ b/src/app/workflow-summary.component.spec.ts
@@ -2,7 +2,7 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { vi } from 'vitest';
 import { WorkflowSummaryComponent } from './workflow-summary.component';
-import { WorkflowSummaryService } from './workflow-summary.service';
+import { WorkflowSummaryService, WorkflowSummary } from './workflow-summary.service';
 import { OrgConnection } from './models/pull-request.model';
 
 const CONNECTIONS: OrgConnection[] = [{ organization: 'my-org', token: 'ghp_test' }];
@@ -77,6 +77,34 @@ describe('WorkflowSummaryComponent', () => {
     TestBed.flushEffects();
 
     expect(summaryServiceSpy.getSummary).not.toHaveBeenCalled();
+  });
+
+  it('retries a trigger bumped during an in-flight load once loading completes', async () => {
+    // First load hangs until we resolve it, keeping isLoading true.
+    let resolveFirst!: (v: WorkflowSummary) => void;
+    const firstLoad = new Promise<WorkflowSummary>(res => { resolveFirst = res; });
+    summaryServiceSpy.getSummary
+      .mockReturnValueOnce(firstLoad)
+      .mockResolvedValueOnce({ success: 1, pending: 0, failed: 0 });
+
+    const fixture = TestBed.createComponent(WorkflowSummaryComponent);
+    fixture.componentRef.setInput('connections', CONNECTIONS);
+    fixture.componentRef.setInput('refreshTrigger', 1);
+    TestBed.flushEffects();
+    expect(summaryServiceSpy.getSummary).toHaveBeenCalledTimes(1);
+
+    // Bump the trigger while the first load is still in flight — must not be dropped.
+    fixture.componentRef.setInput('refreshTrigger', 2);
+    TestBed.flushEffects();
+    expect(summaryServiceSpy.getSummary).toHaveBeenCalledTimes(1);
+
+    // Complete the first load; the missed trigger should now be processed.
+    resolveFirst({ success: 0, pending: 0, failed: 0 });
+    await firstLoad;
+    await Promise.resolve();
+    TestBed.flushEffects();
+
+    expect(summaryServiceSpy.getSummary).toHaveBeenCalledTimes(2);
   });
 
   it('renders the warning indicator when incompleteResults is true', async () => {

--- a/src/app/workflow-summary.component.ts
+++ b/src/app/workflow-summary.component.ts
@@ -18,12 +18,18 @@ export class WorkflowSummaryComponent {
   summary = signal<WorkflowSummary>({ success: 0, pending: 0, failed: 0 });
   isLoading = signal<boolean>(false);
 
+  private lastProcessedTrigger = 0;
+
   constructor() {
     effect(() => {
       const trigger = this.refreshTrigger();
+      // Track isLoading so that a trigger bumped mid-load is retried once the
+      // in-flight load finishes, instead of being silently dropped.
+      const loading = this.isLoading();
       const conns = untracked(this.connections);
 
-      if (conns.length > 0 && trigger > 0 && !untracked(this.isLoading)) {
+      if (trigger > 0 && trigger !== this.lastProcessedTrigger && conns.length > 0 && !loading) {
+        this.lastProcessedTrigger = trigger;
         void this.loadSummary(conns);
       }
     });

--- a/src/app/workflow-summary.component.ts
+++ b/src/app/workflow-summary.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, effect, input, signal, inject, untracked } from '@angular/core';
 import { WorkflowSummaryService, WorkflowSummary } from './workflow-summary.service';
+import { OrgConnection } from './models/pull-request.model';
 
 @Component({
   selector: 'app-workflow-summary',
@@ -11,8 +12,7 @@ import { WorkflowSummaryService, WorkflowSummary } from './workflow-summary.serv
 export class WorkflowSummaryComponent {
   private summaryService = inject(WorkflowSummaryService);
 
-  organization = input('');
-  token = input('');
+  connections = input<OrgConnection[]>([]);
   refreshTrigger = input(0);
 
   summary = signal<WorkflowSummary>({ success: 0, pending: 0, failed: 0 });
@@ -21,19 +21,18 @@ export class WorkflowSummaryComponent {
   constructor() {
     effect(() => {
       const trigger = this.refreshTrigger();
-      const org = untracked(this.organization);
-      const tkn = untracked(this.token);
+      const conns = untracked(this.connections);
 
-      if (org && tkn && trigger > 0 && !untracked(this.isLoading)) {
-        void this.loadSummary(org, tkn);
+      if (conns.length > 0 && trigger > 0 && !untracked(this.isLoading)) {
+        void this.loadSummary(conns);
       }
     });
   }
 
-  private async loadSummary(organization: string, token: string): Promise<void> {
+  private async loadSummary(connections: OrgConnection[]): Promise<void> {
     this.isLoading.set(true);
     try {
-      const summary = await this.summaryService.getSummary(organization, token);
+      const summary = await this.summaryService.getSummary(connections);
       this.summary.set(summary);
     } catch (error) {
       console.error('Failed to load workflow summary', error);

--- a/src/app/workflow-summary.service.ts
+++ b/src/app/workflow-summary.service.ts
@@ -25,23 +25,31 @@ export class WorkflowSummaryService {
       return { success: 0, pending: 0, failed: 0 };
     }
 
-    try {
-      const results = await Promise.all(
-        connections.map(conn => this.fetchWorkflowSummary(conn.organization, conn.token))
-      );
-      return results.reduce(
+    // allSettled so one org's failure doesn't collapse the whole summary; sum the
+    // successful orgs and flag the rest via incompleteResults.
+    const settled = await Promise.allSettled(
+      connections.map(conn => this.fetchWorkflowSummary(conn.organization, conn.token))
+    );
+
+    const anyRejected = settled.some(r => r.status === 'rejected');
+    settled.forEach(r => {
+      if (r.status === 'rejected') {
+        console.error('Failed to fetch workflow summary for one organization', r.reason);
+      }
+    });
+
+    return settled
+      .filter((r): r is PromiseFulfilledResult<WorkflowSummary> => r.status === 'fulfilled')
+      .map(r => r.value)
+      .reduce(
         (acc, r) => ({
           success: acc.success + r.success,
           pending: acc.pending + r.pending,
           failed: acc.failed + r.failed,
-          incompleteResults: acc.incompleteResults || r.incompleteResults,
+          incompleteResults: acc.incompleteResults || Boolean(r.incompleteResults),
         }),
-        { success: 0, pending: 0, failed: 0, incompleteResults: false }
+        { success: 0, pending: 0, failed: 0, incompleteResults: anyRejected }
       );
-    } catch (error) {
-      console.error('Failed to fetch workflow summary', error);
-      return { success: 0, pending: 0, failed: 0 };
-    }
   }
 
   private async fetchWorkflowSummary(organization: string, token: string): Promise<WorkflowSummary> {

--- a/src/app/workflow-summary.service.ts
+++ b/src/app/workflow-summary.service.ts
@@ -5,6 +5,7 @@ import {
   GitHubCombinedStatusResponse,
   GitHubIssueSearchItem,
   GitHubPullRequestDetails,
+  OrgConnection,
 } from './models/pull-request.model';
 import { GitHubSearchService } from './services/github-search.service';
 
@@ -19,13 +20,24 @@ export interface WorkflowSummary {
 export class WorkflowSummaryService {
   private githubSearch = inject(GitHubSearchService);
 
-  async getSummary(organization: string, token: string): Promise<WorkflowSummary> {
-    if (!organization || !token) {
+  async getSummary(connections: OrgConnection[]): Promise<WorkflowSummary> {
+    if (connections.length === 0) {
       return { success: 0, pending: 0, failed: 0 };
     }
 
     try {
-      return await this.fetchWorkflowSummary(organization, token);
+      const results = await Promise.all(
+        connections.map(conn => this.fetchWorkflowSummary(conn.organization, conn.token))
+      );
+      return results.reduce(
+        (acc, r) => ({
+          success: acc.success + r.success,
+          pending: acc.pending + r.pending,
+          failed: acc.failed + r.failed,
+          incompleteResults: acc.incompleteResults || r.incompleteResults,
+        }),
+        { success: 0, pending: 0, failed: 0, incompleteResults: false }
+      );
     } catch (error) {
       console.error('Failed to fetch workflow summary', error);
       return { success: 0, pending: 0, failed: 0 };


### PR DESCRIPTION
## Summary

Users can now configure any number of GitHub organization + token pairs. All configured orgs are searched in parallel when "Find Renovate PRs" is clicked and their results are merged.

## Changes

**Data model**
- New `OrgConnection { organization, token }` interface in `pull-request.model.ts`
- `PullRequest` gains `orgToken: string` so each PR carries the correct token for subsequent API calls (approve, merge, close)

**Storage**
- `SessionStorageService` gains `getJson<T>` / `setJson<T>` helpers
- Connections stored as a JSON array under a new `connections` key
- On first load, legacy `organization` / `token` keys are automatically migrated to the new format — no user action needed

**Connection panel (`SearchFormComponent`)**
- Replaced the two-field form with a two-zone panel:
  - *Configured orgs list* — each row shows the org name, a masked token placeholder, and a remove button; duplicate-org detection with inline warning
  - *Add organization sub-form* — same org + token inputs with Enter-key support
- "Find Renovate PRs" button is now separated from the add form by a divider

**App (`app.ts`)**
- `organization` / `token` signals replaced by a single `connections` signal
- `formValid` is now `connections().length > 0`
- `searchAndProcessPullRequests` runs a `Promise.all` over all connections, merges items, and builds a `tokenByOrg` map so each `PullRequest` gets the right `orgToken`
- `apiRequest` now accepts an explicit `token` argument instead of reading `this.token()`

**Workflow summary**
- `WorkflowSummaryComponent` accepts `connections: OrgConnection[]` instead of separate `organization` / `token` inputs
- `WorkflowSummaryService.getSummary` runs per-org fetches in parallel and sums the results

**Top bar chip**
- 1 org → `github.com / <org-name>`
- 2+ orgs → `github.com · N orgs`

## Test plan

- [ ] Add two orgs in the connection panel — both appear in the list, the chip shows "github.com · 2 orgs"
- [ ] Remove one org — list and chip update immediately, no search triggered
- [ ] Click "Find Renovate PRs" — results from both orgs appear merged
- [ ] Reload the page — connections are restored from sessionStorage
- [ ] Fresh load (no stored data) — empty state, single-org Add form shown
- [ ] `npm test` passes (103 tests)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)