### PR TITLE
chore(deps): remove deprecated @angular/platform-browser-dynamic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@angular/core": "^21.1.1",
         "@angular/forms": "^21.1.1",
         "@angular/platform-browser": "^21.1.1",
-        "@angular/platform-browser-dynamic": "^21.1.1",
         "@angular/router": "^21.1.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
@@ -1217,25 +1216,6 @@
         "@angular/animations": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.18.tgz",
-      "integrity": "sha512-doTDss6GhDTGjVuuANlzFrdYKBqHQVlWgy2tiTjy9EbrmMTOOHg0D6yUQXh1ZqmUWKDZ3owkUjUNGiXt92rQ6w==",
-      "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "21.2.18",
-        "@angular/compiler": "21.2.18",
-        "@angular/core": "21.2.18",
-        "@angular/platform-browser": "21.2.18"
       }
     },
     "node_modules/@angular/router": {
@@ -4228,9 +4208,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4248,9 +4225,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4268,9 +4242,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4288,9 +4259,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@angular/core": "^21.1.1",
     "@angular/forms": "^21.1.1",
     "@angular/platform-browser": "^21.1.1",
-    "@angular/platform-browser-dynamic": "^21.1.1",
     "@angular/router": "^21.1.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"


### PR DESCRIPTION
## Summary

Removes `@angular/platform-browser-dynamic`, flagged as deprecated in the Renovate Dependency Dashboard (#53).

**It's deprecated** — npm reports *"@angular/platform-browser-dynamic is deprecated. Use @angular/platform-browser instead."*

**It's unused** — the app bootstraps the standalone/AOT way and nothing in `src/` imports the dynamic package:

```ts
// src/main.ts
import { bootstrapApplication } from '@angular/platform-browser';
bootstrapApplication(App, appConfig).catch((err) => console.error(err));
```

The dynamic package was only needed for the legacy JIT/NgModule bootstrap (`platformBrowserDynamic().bootstrapModule(AppModule)`). It's a leftover from the old CLI project template. Its replacement, `@angular/platform-browser`, is already a direct dependency.

## Verification

- `npm run build` — succeeds
- `npm run lint` — passes
- `npm test` — 98/98 pass

Once merged, the next Renovate scan will drop the deprecation warning from #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)