### PR TITLE
Redesign phase 2: per-org views via an active-org filter

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,10 +10,12 @@
   }
 
   <!-- Sidebar -->
-  <app-sidebar [groupCount]="prGroups().length" [mobileOpen]="sidebarOpen()">
+  <app-sidebar [groupCount]="visibleGroups().length" [mobileOpen]="sidebarOpen()">
     <app-org-switcher
       [connections]="connections()"
-      (connectionsChange)="onConnectionsChange($event)">
+      [selectedOrg]="selectedOrg()"
+      (connectionsChange)="onConnectionsChange($event)"
+      (selectedOrgChange)="onSelectedOrgChange($event)">
     </app-org-switcher>
   </app-sidebar>
 
@@ -37,18 +39,18 @@
           </button>
 
           <h1 class="text-sm font-semibold text-ink">Overview</h1>
-          @if (prGroups().length > 0) {
+          @if (visibleGroups().length > 0) {
             <span class="rounded-md bg-accent-subtle px-2.5 py-0.5 text-[11px] font-semibold text-accent tabular-nums">
-              {{ prGroups().length }} {{ prGroups().length === 1 ? 'group' : 'groups' }}
+              {{ visibleGroups().length }} {{ visibleGroups().length === 1 ? 'group' : 'groups' }}
             </span>
           }
         </div>
 
         <!-- Right: workflow summary + controls -->
         <div class="flex items-center gap-2 shrink-0">
-          @if (prGroups().length > 0) {
+          @if (visibleGroups().length > 0) {
             <app-workflow-summary
-              [connections]="connections()"
+              [connections]="visibleConnections()"
               [refreshTrigger]="workflowRefreshTrigger()">
             </app-workflow-summary>
           }
@@ -162,13 +164,13 @@
         }
 
         <!-- PR Groups -->
-        @if (prGroups().length > 0) {
+        @if (visibleGroups().length > 0) {
           <div class="flex items-center gap-2 mb-1">
             <h3 class="text-sm font-semibold text-ink">PR Groups</h3>
-            <span class="px-2 py-0.5 rounded-md bg-ghost border border-edge text-xs text-ink-2 font-mono">{{ prGroups().length }}</span>
+            <span class="px-2 py-0.5 rounded-md bg-ghost border border-edge text-xs text-ink-2 font-mono">{{ visibleGroups().length }}</span>
           </div>
           <div class="space-y-2">
-            @for (group of prGroups(); track group.title) {
+            @for (group of visibleGroups(); track group.title) {
               <app-pr-group
                 [group]="group"
                 (toggleGroup)="toggleGroup($event)"
@@ -183,13 +185,25 @@
           </div>
         }
 
-        <!-- Empty state -->
-        @if (searched() && prGroups().length === 0 && !error() && !isLoading()) {
+        <!-- Empty states -->
+        @if (searched() && !error() && !isLoading() && visibleGroups().length === 0) {
           <div class="text-center py-16 text-ink-3">
             <svg class="w-10 h-10 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
             </svg>
-            <p class="text-sm">No open Renovate PRs found for the configured organizations.</p>
+            @if (prGroups().length > 0 && selectedOrg()) {
+              <!-- PRs exist, just none for the active org filter -->
+              <p class="text-sm">No open Renovate PRs found for {{ selectedOrg() }}.</p>
+              <button
+                type="button"
+                (click)="onSelectedOrgChange(null)"
+                class="mt-3 px-3 py-1.5 text-xs font-medium rounded-md border border-edge text-ink-2 hover:bg-ghost transition-colors duration-200"
+              >
+                Show all organizations
+              </button>
+            } @else {
+              <p class="text-sm">No open Renovate PRs found for the configured organizations.</p>
+            }
           </div>
         }
 

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -73,9 +73,14 @@ describe('App', () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  function makeStorageSpy(connectionsValue: unknown = null, orgValue = '', tokenValue = '') {
+  function makeStorageSpy(connectionsValue: unknown = null, orgValue = '', tokenValue = '', selectedOrgValue = '') {
     return {
-      get: vi.fn((key: string) => key === 'organization' ? orgValue : tokenValue),
+      get: vi.fn((key: string) => {
+        if (key === 'organization') return orgValue;
+        if (key === 'token') return tokenValue;
+        if (key === 'selectedOrg') return selectedOrgValue;
+        return '';
+      }),
       set: vi.fn(),
       remove: vi.fn(),
       getJson: vi.fn((key: string) => key === 'connections' ? connectionsValue : null),
@@ -274,24 +279,27 @@ describe('App', () => {
   describe('toggleGroup', () => {
     it('expands a collapsed group', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      const group = makeGroup({ isExpanded: false });
+      const group = makeGroup({ prs: [makePr()] });
       app.prGroups.set([group]);
 
       app.toggleGroup(group);
 
-      expect(app.prGroups()[0].isExpanded).toBe(true);
+      expect(app.expandedGroupTitles().has(group.title)).toBe(true);
+      expect(app.visibleGroups()[0].isExpanded).toBe(true);
     });
 
     it('collapses an expanded group and clears its PR ids from expandedPrIds', () => {
       const app = TestBed.createComponent(App).componentInstance;
       const pr = makePr({ id: 7 });
-      const group = makeGroup({ prs: [pr], isExpanded: true });
+      const group = makeGroup({ prs: [pr] });
       app.prGroups.set([group]);
+      app.expandedGroupTitles.set(new Set([group.title]));
       app.expandedPrIds.set(new Set([7]));
 
       app.toggleGroup(group);
 
-      expect(app.prGroups()[0].isExpanded).toBe(false);
+      expect(app.expandedGroupTitles().has(group.title)).toBe(false);
+      expect(app.visibleGroups()[0].isExpanded).toBe(false);
       expect(app.expandedPrIds().has(7)).toBe(false);
     });
   });
@@ -532,14 +540,14 @@ describe('App', () => {
       expect(fixture.nativeElement.textContent).toContain('github.com');
     });
 
-    it('shows an org count in the sidebar switcher for multiple connections', () => {
+    it('shows "All organizations" in the sidebar switcher for multiple connections', () => {
       const fixture = TestBed.createComponent(App);
       fixture.componentInstance.connections.set([
         { organization: 'org-a', token: 'ghp_aaa' },
         { organization: 'org-b', token: 'ghp_bbb' },
       ]);
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toContain('2 organizations');
+      expect(fixture.nativeElement.textContent).toContain('All organizations');
     });
 
     it('prompts to add an organization and shows onboarding when none are configured', () => {
@@ -661,6 +669,162 @@ describe('App', () => {
 
       expect(app.incompleteResults()).toBe(false);
       expect(app.isLoading()).toBe(false);
+    });
+  });
+
+  describe('per-org views', () => {
+    function seedTwoOrgGroups(app: App) {
+      app.connections.set([
+        { organization: 'org-a', token: 'a' },
+        { organization: 'org-b', token: 'b' },
+      ]);
+      app.prGroups.set([
+        makeGroup({
+          title: 'Update dependency foo to v2',
+          prs: [
+            makePr({ id: 1, repoOwner: 'org-a', workflowStatus: 'success', ciStatus: 'success' }),
+            makePr({ id: 2, repoOwner: 'org-b', workflowStatus: 'failure', ciStatus: 'failure' }),
+          ],
+        }),
+        makeGroup({
+          title: 'Update dependency bar to v3',
+          prs: [makePr({ id: 3, repoOwner: 'org-b', workflowStatus: 'pending', ciStatus: 'pending' })],
+        }),
+      ]);
+    }
+
+    it('shows all groups and PRs when no org is selected', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedTwoOrgGroups(app);
+
+      const groups = app.visibleGroups();
+      expect(groups).toHaveLength(2);
+      expect(groups[0].prs).toHaveLength(2);
+    });
+
+    it('filters PRs by the selected org and drops groups left empty', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedTwoOrgGroups(app);
+
+      app.selectedOrg.set('org-a');
+
+      const groups = app.visibleGroups();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].title).toBe('Update dependency foo to v2');
+      expect(groups[0].prs.map(pr => pr.id)).toEqual([1]);
+    });
+
+    it('matches the selected org case-insensitively', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedTwoOrgGroups(app);
+
+      app.selectedOrg.set('ORG-A');
+
+      expect(app.visibleGroups()).toHaveLength(1);
+    });
+
+    it('derives group status and workflow summary from the visible PRs only', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedTwoOrgGroups(app);
+
+      // Unfiltered, the mixed group fails; filtered to org-a it succeeds.
+      expect(app.visibleGroups()[0].aggregateCiStatus).toBe('failure');
+      expect(app.visibleGroups()[0].workflowSummary).toEqual({ success: 1, pending: 0, failed: 1 });
+
+      app.selectedOrg.set('org-a');
+
+      expect(app.visibleGroups()[0].aggregateCiStatus).toBe('success');
+      expect(app.visibleGroups()[0].workflowSummary).toEqual({ success: 1, pending: 0, failed: 0 });
+    });
+
+    it('narrows visibleConnections to the selected org', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedTwoOrgGroups(app);
+
+      expect(app.visibleConnections()).toHaveLength(2);
+
+      app.selectedOrg.set('org-b');
+
+      expect(app.visibleConnections()).toEqual([{ organization: 'org-b', token: 'b' }]);
+    });
+
+    it('names the selected org in the subtitle', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedTwoOrgGroups(app);
+
+      app.selectedOrg.set('org-a');
+
+      expect(app.subtitle()).toContain('the org-a organization');
+    });
+
+    it('onSelectedOrgChange persists the selection and refreshes the workflow summary', () => {
+      const storageSpy = makeStorageSpy();
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      const triggerBefore = app.workflowRefreshTrigger();
+
+      app.onSelectedOrgChange('org-a');
+      expect(app.selectedOrg()).toBe('org-a');
+      expect(storageSpy.set).toHaveBeenCalledWith('selectedOrg', 'org-a');
+      expect(app.workflowRefreshTrigger()).toBe(triggerBefore + 1);
+
+      app.onSelectedOrgChange(null);
+      expect(storageSpy.set).toHaveBeenCalledWith('selectedOrg', '');
+    });
+
+    it('restores a persisted selection that matches a configured org', () => {
+      stubSearchService();
+      const storageSpy = makeStorageSpy(
+        [{ organization: 'Org-A', token: 'a' }], '', '', 'org-a');
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      // Restored with the connection's canonical casing.
+      expect(app.selectedOrg()).toBe('Org-A');
+    });
+
+    it('ignores a persisted selection that no longer matches any connection', () => {
+      stubSearchService();
+      const storageSpy = makeStorageSpy(
+        [{ organization: 'org-a', token: 'a' }], '', '', 'gone-org');
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      expect(app.selectedOrg()).toBeNull();
+    });
+
+    it('resets the selection when the selected org is removed', () => {
+      stubSearchService();
+      const storageSpy = makeStorageSpy();
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      app.onConnectionsChange([
+        { organization: 'org-a', token: 'a' },
+        { organization: 'org-b', token: 'b' },
+      ]);
+      app.onSelectedOrgChange('org-b');
+
+      app.onConnectionsChange([{ organization: 'org-a', token: 'a' }]);
+
+      expect(app.selectedOrg()).toBeNull();
+    });
+
+    it('keeps the selection when an unrelated org is removed', () => {
+      stubSearchService();
+      const app = TestBed.createComponent(App).componentInstance;
+      app.onConnectionsChange([
+        { organization: 'org-a', token: 'a' },
+        { organization: 'org-b', token: 'b' },
+      ]);
+      app.onSelectedOrgChange('org-a');
+
+      app.onConnectionsChange([{ organization: 'org-a', token: 'a' }]);
+
+      expect(app.selectedOrg()).toBe('org-a');
     });
   });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,6 +3,7 @@ import { DOCUMENT } from '@angular/common';
 import {
   OrgConnection,
   PrGroup,
+  PrGroupData,
   PullRequest,
   GitHubCheckRunsResponse,
   GitHubCombinedStatusResponse,
@@ -33,13 +34,16 @@ export class App {
 
   // --- STATE SIGNALS ---
   connections = signal<OrgConnection[]>(this.loadConnections());
+  // The active org filter: null shows every configured organization.
+  selectedOrg = signal<string | null>(this.loadSelectedOrg());
   darkMode = signal<boolean>(this.getInitialDarkMode());
-  prGroups = signal<PrGroup[]>([]);
+  prGroups = signal<PrGroupData[]>([]);
   isLoading = signal<boolean>(false);
   error = signal<string | null>(null);
   incompleteResults = signal<boolean>(false);
   searched = signal<boolean>(false);
   workflowRefreshTrigger = signal<number>(0);
+  expandedGroupTitles = signal<Set<string>>(new Set());
   expandedPrIds = signal<Set<number>>(new Set());
   sidebarOpen = signal<boolean>(false);
 
@@ -57,6 +61,10 @@ export class App {
   );
 
   subtitle = computed(() => {
+    const selected = this.selectedOrg();
+    if (selected) {
+      return `Monitor and manage Renovate pull requests across the ${selected} organization`;
+    }
     const conns = this.connections();
     if (conns.length === 1) {
       return `Monitor and manage Renovate pull requests across the ${conns[0].organization} organization`;
@@ -65,6 +73,37 @@ export class App {
       return `Monitor and manage Renovate pull requests across ${conns.length} GitHub organizations`;
     }
     return 'Monitor and manage Renovate pull requests across your GitHub organizations';
+  });
+
+  /** Connections narrowed to the active org filter (all of them when unfiltered). */
+  visibleConnections = computed(() => {
+    const selected = this.selectedOrg()?.toLowerCase();
+    if (!selected) return this.connections();
+    return this.connections().filter(c => c.organization.toLowerCase() === selected);
+  });
+
+  /**
+   * The groups shown on the board: raw groups narrowed to the active org
+   * filter, with per-group display state derived from the visible PRs so
+   * counts and statuses always match what is on screen.
+   */
+  visibleGroups = computed<PrGroup[]>(() => {
+    const selected = this.selectedOrg()?.toLowerCase();
+    const expanded = this.expandedGroupTitles();
+    return this.prGroups()
+      .map(group => {
+        const prs = selected
+          ? group.prs.filter(pr => pr.repoOwner.toLowerCase() === selected)
+          : group.prs;
+        return {
+          title: group.title,
+          prs,
+          aggregateCiStatus: this.calculateAggregateStatus(prs.map(pr => pr.ciStatus)),
+          isExpanded: expanded.has(group.title),
+          workflowSummary: this.calculateWorkflowSummary(prs),
+        };
+      })
+      .filter(group => group.prs.length > 0);
   });
 
   constructor() {
@@ -91,6 +130,12 @@ export class App {
     this.connections.set(sanitized);
     this.storage.setJson(SESSION_KEYS.connections, sanitized);
 
+    // Reset the org filter if the selected org was just removed.
+    const selected = this.selectedOrg()?.toLowerCase();
+    if (selected && !sanitized.some(c => c.organization.toLowerCase() === selected)) {
+      this.onSelectedOrgChange(null);
+    }
+
     // Keep results in sync with the connection list: re-search when orgs
     // remain, clear the board when the last one was removed.
     if (sanitized.length > 0) {
@@ -103,6 +148,23 @@ export class App {
       this.searched.set(false);
       this.isLoading.set(false);
     }
+  }
+
+  onSelectedOrgChange(org: string | null): void {
+    this.selectedOrg.set(org);
+    this.storage.set(SESSION_KEYS.selectedOrg, org ?? '');
+    // Rescope the top-bar workflow summary to the newly visible connections.
+    this.bumpWorkflowSummaryRefresh();
+  }
+
+  private loadSelectedOrg(): string | null {
+    const stored = this.storage.get(SESSION_KEYS.selectedOrg).trim();
+    if (!stored) return null;
+    // Only honor a persisted selection that still matches a configured org.
+    const match = this.connections().find(
+      c => c.organization.toLowerCase() === stored.toLowerCase(),
+    );
+    return match ? match.organization : null;
   }
 
   private loadConnections(): OrgConnection[] {
@@ -238,7 +300,7 @@ export class App {
       const tokenByOrg = new Map(connections.map(c => [c.organization.toLowerCase(), c.token]));
 
       // Step 2: Group PRs by title
-      const groupsMap = new Map<string, PrGroup>();
+      const groupsMap = new Map<string, PrGroupData>();
       allItems.forEach((item: GitHubIssueSearchItem) => {
         const repoUrlParts = item.repository_url.split('/');
         const repoName = repoUrlParts.pop();
@@ -276,13 +338,7 @@ export class App {
         };
 
         if (!groupsMap.has(pr.title)) {
-          groupsMap.set(pr.title, {
-            title: pr.title,
-            prs: [],
-            aggregateCiStatus: 'unknown',
-            isExpanded: false,
-            workflowSummary: { success: 0, pending: 0, failed: 0 }
-          });
+          groupsMap.set(pr.title, { title: pr.title, prs: [] });
         }
         groupsMap.get(pr.title)!.prs.push(pr);
       });
@@ -297,13 +353,10 @@ export class App {
 
       if (generation !== this.searchGeneration) return;
 
-      // Step 4: Calculate aggregate status and workflow summary for each group
-      groupsMap.forEach(group => {
-        group.aggregateCiStatus = this.calculateAggregateStatus(group.prs.map(p => p.ciStatus));
-        group.workflowSummary = this.calculateWorkflowSummary(group.prs);
-      });
-
+      // Aggregate statuses and workflow summaries are derived per visible
+      // group by the visibleGroups computed, so only raw data is stored.
       this.prGroups.set(Array.from(groupsMap.values()));
+      this.expandedGroupTitles.set(new Set());
       this.expandedPrIds.set(new Set());
 
       // Trigger workflow summary refresh
@@ -501,12 +554,9 @@ export class App {
   }
 
   removePrFromGroup(prToRemove: PullRequest) {
-    const currentGroups = this.prGroups();
-    const updatedGroups = currentGroups.map(group => {
-      // Filter out the closed/merged PR
-      group.prs = group.prs.filter(p => p.id !== prToRemove.id);
-      return group;
-    }).filter(group => group.prs.length > 0); // Remove group if it becomes empty
+    const updatedGroups = this.prGroups()
+      .map(group => ({ ...group, prs: group.prs.filter(p => p.id !== prToRemove.id) }))
+      .filter(group => group.prs.length > 0); // Remove group if it becomes empty
     this.prGroups.set(updatedGroups);
 
     if (this.expandedPrIds().has(prToRemove.id)) {
@@ -518,17 +568,21 @@ export class App {
 
   setPrProcessingState(prToUpdate: PullRequest, isProcessing: boolean) {
      prToUpdate.isProcessing = isProcessing;
-     this.prGroups.set([...this.prGroups()]); // Trigger change detection
+     this.prGroups.set([...this.prGroups()]); // New array identity so visibleGroups recomputes
   }
 
   toggleGroup(group: PrGroup) {
-    group.isExpanded = !group.isExpanded;
-    if (!group.isExpanded) {
-      const updated = new Set(this.expandedPrIds());
-      group.prs.forEach(pr => updated.delete(pr.id));
-      this.expandedPrIds.set(updated);
+    const expanded = new Set(this.expandedGroupTitles());
+    if (expanded.has(group.title)) {
+      expanded.delete(group.title);
+      // Collapse the group's PR detail panels along with it.
+      const prIds = new Set(this.expandedPrIds());
+      group.prs.forEach(pr => prIds.delete(pr.id));
+      this.expandedPrIds.set(prIds);
+    } else {
+      expanded.add(group.title);
     }
-    this.prGroups.set([...this.prGroups()]); // Trigger change detection
+    this.expandedGroupTitles.set(expanded);
   }
 
   togglePullRequest(pr: PullRequest) {

--- a/src/app/components/org-switcher/org-switcher.component.html
+++ b/src/app/components/org-switcher/org-switcher.component.html
@@ -54,16 +54,71 @@
       <div class="p-1.5">
         <p class="px-2 pb-1 pt-0.5 text-[10px] font-semibold uppercase tracking-wider text-ink-3">Organizations</p>
 
-        @for (conn of connections(); track conn.organization) {
-          <div class="flex items-center gap-2.5 rounded-md px-2 py-2">
-            <span
-              class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-gradient-to-br from-slate-600 to-slate-800 text-[11px] font-bold text-white"
-              aria-hidden="true"
-            >{{ conn.organization.charAt(0).toUpperCase() }}</span>
-            <span class="min-w-0 flex-1">
-              <span class="block truncate text-[13px] font-medium text-ink">{{ conn.organization }}</span>
-              <span class="block font-mono text-[11px] text-ink-3 select-none" aria-hidden="true">••••••••</span>
+        @if (showSelection()) {
+          <button
+            type="button"
+            (click)="selectOrg(null)"
+            class="flex w-full items-center gap-2.5 rounded-md px-2 py-2 transition-colors hover:bg-ghost focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            [class.bg-accent-subtle]="selectedOrg() === null"
+            [attr.aria-pressed]="selectedOrg() === null"
+          >
+            <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-ghost text-ink-3" aria-hidden="true">
+              <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <rect x="3" y="3" width="7" height="7" rx="1"/>
+                <rect x="14" y="3" width="7" height="7" rx="1"/>
+                <rect x="3" y="14" width="7" height="7" rx="1"/>
+                <rect x="14" y="14" width="7" height="7" rx="1"/>
+              </svg>
             </span>
+            <span class="min-w-0 flex-1 text-left">
+              <span class="block truncate text-[13px] font-medium text-ink">All organizations</span>
+              <span class="block text-[11px] text-ink-3">{{ connections().length }} configured</span>
+            </span>
+            @if (selectedOrg() === null) {
+              <svg class="h-3.5 w-3.5 shrink-0 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+              </svg>
+            }
+          </button>
+        }
+
+        @for (conn of connections(); track conn.organization) {
+          <div class="flex items-center gap-1">
+            @if (showSelection()) {
+              <button
+                type="button"
+                (click)="selectOrg(conn.organization)"
+                class="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-2 transition-colors hover:bg-ghost focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                [class.bg-accent-subtle]="isActiveOrg(conn.organization)"
+                [attr.aria-pressed]="isActiveOrg(conn.organization)"
+                [attr.aria-label]="'Show only ' + conn.organization"
+              >
+                <span
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-gradient-to-br from-slate-600 to-slate-800 text-[11px] font-bold text-white"
+                  aria-hidden="true"
+                >{{ conn.organization.charAt(0).toUpperCase() }}</span>
+                <span class="min-w-0 flex-1 text-left">
+                  <span class="block truncate text-[13px] font-medium text-ink">{{ conn.organization }}</span>
+                  <span class="block font-mono text-[11px] text-ink-3 select-none" aria-hidden="true">••••••••</span>
+                </span>
+                @if (isActiveOrg(conn.organization)) {
+                  <svg class="h-3.5 w-3.5 shrink-0 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                  </svg>
+                }
+              </button>
+            } @else {
+              <span class="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-2">
+                <span
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-gradient-to-br from-slate-600 to-slate-800 text-[11px] font-bold text-white"
+                  aria-hidden="true"
+                >{{ conn.organization.charAt(0).toUpperCase() }}</span>
+                <span class="min-w-0 flex-1">
+                  <span class="block truncate text-[13px] font-medium text-ink">{{ conn.organization }}</span>
+                  <span class="block font-mono text-[11px] text-ink-3 select-none" aria-hidden="true">••••••••</span>
+                </span>
+              </span>
+            }
             <button
               type="button"
               (click)="removeConnection(conn.organization)"

--- a/src/app/components/org-switcher/org-switcher.component.spec.ts
+++ b/src/app/components/org-switcher/org-switcher.component.spec.ts
@@ -47,9 +47,78 @@ describe('OrgSwitcherComponent', () => {
       expect(fixture.nativeElement.textContent).toContain('org-a');
     });
 
-    it('shows a count when multiple orgs are configured', () => {
+    it('shows "All organizations" when multiple orgs are configured and none is selected', () => {
       const fixture = createFixture([ORG_A, ORG_B]);
-      expect(fixture.nativeElement.textContent).toContain('2 organizations');
+      expect(fixture.nativeElement.textContent).toContain('All organizations');
+    });
+
+    it('shows the selected org when one is active', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      fixture.componentRef.setInput('selectedOrg', 'org-b');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('org-b');
+    });
+  });
+
+  describe('org selection', () => {
+    it('offers an "All organizations" option only when multiple orgs are configured', () => {
+      const multi = createFixture([ORG_A, ORG_B]);
+      openPopover(multi);
+      expect(overlayEl.textContent).toContain('All organizations');
+      multi.componentInstance.close();
+      multi.detectChanges();
+
+      const single = createFixture([ORG_A]);
+      openPopover(single);
+      expect(overlayEl.textContent).not.toContain('All organizations');
+    });
+
+    it('emits selectedOrgChange with the org and closes when an org is clicked', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      openPopover(fixture);
+
+      const emitted: (string | null)[] = [];
+      fixture.componentInstance.selectedOrgChange.subscribe((v: string | null) => emitted.push(v));
+
+      (overlayEl.querySelector('[aria-label="Show only org-b"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(emitted).toEqual(['org-b']);
+      expect(fixture.componentInstance.open()).toBe(false);
+    });
+
+    it('emits null when "All organizations" is clicked', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      fixture.componentRef.setInput('selectedOrg', 'org-a');
+      openPopover(fixture);
+
+      const emitted: (string | null)[] = [];
+      fixture.componentInstance.selectedOrgChange.subscribe((v: string | null) => emitted.push(v));
+
+      const allBtn = Array.from(overlayEl.querySelectorAll('button')).find(
+        b => b.textContent?.includes('All organizations')) as HTMLButtonElement;
+      allBtn.click();
+
+      expect(emitted).toEqual([null]);
+    });
+
+    it('marks the active org with aria-pressed', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      fixture.componentRef.setInput('selectedOrg', 'org-a');
+      openPopover(fixture);
+
+      expect(overlayEl.querySelector('[aria-label="Show only org-a"]')?.getAttribute('aria-pressed')).toBe('true');
+      expect(overlayEl.querySelector('[aria-label="Show only org-b"]')?.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('does not render selectable org rows with a single connection', () => {
+      const fixture = createFixture([ORG_A]);
+      openPopover(fixture);
+
+      expect(overlayEl.querySelector('[aria-label^="Show only"]')).toBeNull();
+      // The org is still listed (with its remove button).
+      expect(overlayEl.textContent).toContain('org-a');
+      expect(overlayEl.querySelector('[aria-label="Remove org-a"]')).not.toBeNull();
     });
   });
 

--- a/src/app/components/org-switcher/org-switcher.component.ts
+++ b/src/app/components/org-switcher/org-switcher.component.ts
@@ -5,8 +5,8 @@ import { OrgConnection } from '../../models/pull-request.model';
 
 /**
  * Sidebar organization switcher: a trigger button summarizing the configured
- * connections, with a CDK-overlay popover for listing, adding, and removing
- * GitHub organizations.
+ * connections, with a CDK-overlay popover for selecting the active org filter
+ * and for listing, adding, and removing GitHub organizations.
  */
 @Component({
   selector: 'app-org-switcher',
@@ -16,7 +16,10 @@ import { OrgConnection } from '../../models/pull-request.model';
 })
 export class OrgSwitcherComponent {
   connections = input<OrgConnection[]>([]);
+  /** Active org filter; null means "all organizations". */
+  selectedOrg = input<string | null>(null);
   connectionsChange = output<OrgConnection[]>();
+  selectedOrgChange = output<string | null>();
 
   open = signal(false);
   view = signal<'list' | 'add'>('list');
@@ -31,16 +34,33 @@ export class OrgSwitcherComponent {
   ];
 
   triggerLabel = computed(() => {
+    const selected = this.selectedOrg();
+    if (selected) return selected;
     const conns = this.connections();
     if (conns.length === 0) return 'Add organization';
     if (conns.length === 1) return conns[0].organization;
-    return `${conns.length} organizations`;
+    return 'All organizations';
   });
 
   avatarInitial = computed(() => {
+    const selected = this.selectedOrg();
+    if (selected) return selected.charAt(0).toUpperCase();
     const conns = this.connections();
-    return conns.length > 0 ? conns[0].organization.charAt(0).toUpperCase() : '+';
+    if (conns.length === 1) return conns[0].organization.charAt(0).toUpperCase();
+    return conns.length > 1 ? String(conns.length) : '+';
   });
+
+  /** The org filter is only meaningful with more than one configured org. */
+  showSelection = computed(() => this.connections().length > 1);
+
+  isActiveOrg(organization: string): boolean {
+    return this.selectedOrg()?.toLowerCase() === organization.toLowerCase();
+  }
+
+  selectOrg(organization: string | null): void {
+    this.selectedOrgChange.emit(organization);
+    this.close();
+  }
 
   isDuplicateOrg = computed(() => {
     // GitHub org names are case-insensitive, so compare normalized values while

--- a/src/app/models/pull-request.model.ts
+++ b/src/app/models/pull-request.model.ts
@@ -88,9 +88,17 @@ export interface PullRequest {
   allowRebaseMerge?: boolean;
 }
 
-export interface PrGroup {
+/** Raw grouped search results: PRs sharing a Renovate title, across all orgs. */
+export interface PrGroupData {
   title: string;
   prs: PullRequest[];
+}
+
+/**
+ * View model consumed by PrGroupComponent: a (possibly org-filtered) group
+ * with its display state derived from the visible PRs.
+ */
+export interface PrGroup extends PrGroupData {
   aggregateCiStatus: 'success' | 'failure' | 'pending' | 'mixed' | 'unknown';
   isExpanded: boolean;
   workflowSummary: { success: number; pending: number; failed: number };

--- a/src/app/services/session-storage.service.ts
+++ b/src/app/services/session-storage.service.ts
@@ -4,6 +4,7 @@ export const SESSION_KEYS = {
   organization: 'organization',
   token: 'token',
   connections: 'connections',
+  selectedOrg: 'selectedOrg',
 } as const;
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
Phase 2 of the UI redesign (#76): the PR board can now be viewed **per organization** instead of always aggregating every configured org.

## What changed

- **Active-org filter in the org switcher**: with more than one org configured, the popover offers "All organizations" plus one selectable entry per connection (checkmark on the active one, demo-style). The trigger button and page subtitle reflect the selection.
- **Client-side filtering**: results are still fetched for all orgs in one sweep; selecting an org filters by `pr.repoOwner` with `computed()` — no new API calls when switching.
- **Derived group state** (the enabling refactor): `prGroups` now holds raw title+PRs data (`PrGroupData`). A `visibleGroups` computed produces the `PrGroup` view models — filtering each group's PRs, recomputing aggregate CI status and workflow counts *from the visible PRs only*, and dropping groups left empty. Group expansion moved from a mutated `isExpanded` field to an `expandedGroupTitles` signal, which also removes the old `prGroups.set([...prGroups()])` change-detection hacks.
- **Scoped chrome**: the top-bar workflow summary, group-count badges, and sidebar badge all follow the filter (`visibleConnections` / `visibleGroups`); the summary refreshes on selection change.
- **Group actions respect the filter**: "Close All" / "Approve & Merge All" receive the filtered view model, so with an org selected they act only on that org's PRs in the group.
- **Persistence**: the selection is stored in sessionStorage, restored only if it still matches a configured org (canonical casing), and reset automatically when the selected org is removed.
- **Empty state**: when PRs exist but none match the filter, a distinct message names the org and offers a "Show all organizations" shortcut.

## Tests

17 new tests: filtering (incl. case-insensitivity and empty-group dropping), per-org derivation of status/counts, `visibleConnections`, subtitle, persistence/restore/reset of the selection, switcher selection UI (All-orgs option gating, emit-and-close, `aria-pressed`, single-org non-selectable rows). `npm run lint`, `npm test` (151 tests), and `npm run build` all pass.

Verified in the browser with two configured orgs: switcher list with "All organizations", selecting an org updates trigger/subtitle/board, checkmark tracks the active entry.

Refs #76 — phase 3 (overview stat tiles) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
