### PR TITLE
Redesign phase 4: filter bar, unified group list, PR-row polish

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -161,26 +161,76 @@
           </div>
         }
 
+        <!-- Ready-to-merge callout -->
+        @if (readyToMergePrs().length > 0) {
+          <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-lg border border-accent/20 bg-accent/5 px-4 py-3">
+            <div class="flex items-center gap-3 min-w-0">
+              <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent/10" aria-hidden="true">
+                <svg class="w-4 h-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <span class="text-sm font-medium text-ink">
+                  {{ readyToMergePrs().length }} {{ readyToMergePrs().length === 1 ? 'pull request is' : 'pull requests are' }} ready to merge
+                </span>
+                <span class="ml-2 text-[13px] text-ink-3">All CI checks passed</span>
+              </div>
+            </div>
+            <button
+              type="button"
+              (click)="mergeAllReady()"
+              [disabled]="isBulkProcessing()"
+              class="shrink-0 px-4 py-2 rounded-md bg-accent text-white text-[13px] font-medium shadow-sm hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200"
+            >
+              Merge All Ready
+            </button>
+          </div>
+        }
+
         <!-- PR Groups -->
         @if (visibleGroups().length > 0) {
-          <div class="flex items-center gap-2 mb-1">
-            <h3 class="text-sm font-semibold text-ink">PR Groups</h3>
-            <span class="px-2 py-0.5 rounded-md bg-ghost border border-edge text-xs text-ink-2 font-mono">{{ visibleGroups().length }}</span>
-          </div>
-          <div class="space-y-2">
-            @for (group of visibleGroups(); track group.title) {
-              <app-pr-group
-                [group]="group"
-                (toggleGroup)="toggleGroup($event)"
-                (closePr)="closePullRequest($event)"
-                (approveAndMergePr)="approveAndMergePullRequest($event)"
-                (closeGroupPrs)="closeGroupPullRequests($event)"
-                (approveAndMergeGroupPrs)="approveAndMergeGroupPullRequests($event)"
-                (togglePr)="togglePullRequest($event)"
-                [expandedPrIds]="expandedPrIds()">
-              </app-pr-group>
-            }
-          </div>
+          <app-filter-bar
+            [(searchText)]="searchFilter"
+            [(status)]="statusFilter"
+            [(sortBy)]="sortBy"
+            [resultCount]="filteredGroups().length"
+            [totalCount]="visibleGroups().length">
+          </app-filter-bar>
+
+          @if (filteredGroups().length > 0) {
+            <div class="rounded-lg border border-edge bg-panel divide-y divide-edge overflow-hidden">
+              @for (group of filteredGroups(); track group.title) {
+                <app-pr-group
+                  [group]="group"
+                  (toggleGroup)="toggleGroup($event)"
+                  (closePr)="closePullRequest($event)"
+                  (approveAndMergePr)="approveAndMergePullRequest($event)"
+                  (closeGroupPrs)="closeGroupPullRequests($event)"
+                  (approveAndMergeGroupPrs)="approveAndMergeGroupPullRequests($event)"
+                  (togglePr)="togglePullRequest($event)"
+                  [expandedPrIds]="expandedPrIds()">
+                </app-pr-group>
+              }
+            </div>
+          } @else {
+            <!-- Filters excluded every group -->
+            <div class="flex flex-col items-center justify-center rounded-lg border border-edge bg-panel py-16 text-ink-3">
+              <svg class="w-10 h-10 mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                <circle cx="11" cy="11" r="8"/>
+                <path stroke-linecap="round" d="M21 21l-4.35-4.35"/>
+              </svg>
+              <p class="text-sm font-medium text-ink-2">No matching PR groups</p>
+              <p class="mt-1 text-[13px]">Try adjusting your filters or search query.</p>
+              <button
+                type="button"
+                (click)="clearFilters()"
+                class="mt-3 px-3 py-1.5 text-xs font-medium rounded-md border border-edge text-ink-2 hover:bg-ghost transition-colors duration-200"
+              >
+                Clear filters
+              </button>
+            </div>
+          }
         }
 
         <!-- Empty states -->

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -64,6 +64,9 @@ function mockMatchMedia(prefersDark: boolean) {
 
 describe('App', () => {
   beforeEach(async () => {
+    // Tests that use the real SessionStorageService write to jsdom's
+    // sessionStorage; clear it so state never leaks between tests.
+    sessionStorage.clear();
     mockMatchMedia(false);
     await TestBed.configureTestingModule({
       imports: [App],
@@ -71,7 +74,10 @@ describe('App', () => {
     }).compileComponents();
   });
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
 
   function makeStorageSpy(connectionsValue: unknown = null, orgValue = '', tokenValue = '', selectedOrgValue = '') {
     return {
@@ -823,6 +829,150 @@ describe('App', () => {
       app.onConnectionsChange([{ organization: 'org-a', token: 'a' }]);
 
       expect(app.selectedOrg()).toBe('org-a');
+    });
+  });
+
+  describe('filteredGroups', () => {
+    function seedGroups(app: App) {
+      app.prGroups.set([
+        makeGroup({
+          title: 'Update dependency ruby to v3',
+          prs: [
+            makePr({ id: 1, repoName: 'repo-one', workflowStatus: 'failure' }),
+            makePr({ id: 2, repoName: 'repo-two', workflowStatus: 'success' }),
+          ],
+        }),
+        makeGroup({
+          title: 'Update actions/checkout action to v5',
+          prs: [makePr({ id: 3, repoName: 'ci-repo', workflowStatus: 'success' })],
+        }),
+        makeGroup({
+          title: 'Update dependency zebra to v9',
+          prs: [
+            makePr({ id: 4, repoName: 'zoo', workflowStatus: 'pending' }),
+            makePr({ id: 5, repoName: 'zoo-two', workflowStatus: 'success' }),
+            makePr({ id: 6, repoName: 'zoo-three', workflowStatus: 'success' }),
+          ],
+        }),
+      ]);
+    }
+
+    it('matches group titles case-insensitively', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedGroups(app);
+
+      app.searchFilter.set('RUBY');
+
+      expect(app.filteredGroups().map(g => g.title)).toEqual(['Update dependency ruby to v3']);
+    });
+
+    it('matches repositories inside groups', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedGroups(app);
+
+      app.searchFilter.set('ci-repo');
+
+      expect(app.filteredGroups().map(g => g.title)).toEqual(['Update actions/checkout action to v5']);
+    });
+
+    it('keeps only groups containing a PR with the selected status', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedGroups(app);
+
+      app.statusFilter.set('failure');
+      expect(app.filteredGroups().map(g => g.title)).toEqual(['Update dependency ruby to v3']);
+
+      app.statusFilter.set('pending');
+      expect(app.filteredGroups().map(g => g.title)).toEqual(['Update dependency zebra to v9']);
+    });
+
+    it('sorts by failures by default, with PR-count and name alternatives', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedGroups(app);
+
+      expect(app.filteredGroups()[0].title).toBe('Update dependency ruby to v3'); // 1 failure
+
+      app.sortBy.set('prs');
+      expect(app.filteredGroups()[0].title).toBe('Update dependency zebra to v9'); // 3 PRs
+
+      app.sortBy.set('name');
+      expect(app.filteredGroups()[0].title).toBe('Update actions/checkout action to v5');
+    });
+
+    it('clearFilters resets search and status', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      seedGroups(app);
+      app.searchFilter.set('nothing-matches');
+      app.statusFilter.set('failure');
+      expect(app.filteredGroups()).toHaveLength(0);
+
+      app.clearFilters();
+
+      expect(app.filteredGroups()).toHaveLength(3);
+    });
+
+    it('applies on top of the org filter', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      app.prGroups.set([
+        makeGroup({
+          title: 'Update dependency foo to v2',
+          prs: [
+            makePr({ id: 1, repoOwner: 'org-a', workflowStatus: 'failure' }),
+            makePr({ id: 2, repoOwner: 'org-b', workflowStatus: 'failure' }),
+          ],
+        }),
+      ]);
+
+      app.selectedOrg.set('org-b');
+      app.statusFilter.set('failure');
+
+      const groups = app.filteredGroups();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].prs.map(pr => pr.id)).toEqual([2]);
+    });
+  });
+
+  describe('mergeAllReady', () => {
+    it('approves and merges only PRs whose workflows passed', async () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      app.prGroups.set([
+        makeGroup({
+          prs: [
+            makePr({ id: 1, number: 10, workflowStatus: 'success', commits: 1, allowRebaseMerge: true }),
+            makePr({ id: 2, number: 11, workflowStatus: 'failure' }),
+            makePr({ id: 3, number: 12, workflowStatus: 'pending' }),
+          ],
+        }),
+      ]);
+
+      expect(app.readyToMergePrs().map(pr => pr.number)).toEqual([10]);
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+      await app.mergeAllReady();
+
+      const calledUrls = fetchSpy.mock.calls.map(args => String(args[0]));
+      expect(calledUrls.some(u => u.includes('/pulls/10/'))).toBe(true);
+      expect(calledUrls.some(u => u.includes('/pulls/11/'))).toBe(false);
+      expect(calledUrls.some(u => u.includes('/pulls/12/'))).toBe(false);
+    });
+
+    it('only counts PRs visible under the active org filter', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      app.prGroups.set([
+        makeGroup({
+          prs: [
+            makePr({ id: 1, repoOwner: 'org-a', workflowStatus: 'success' }),
+            makePr({ id: 2, repoOwner: 'org-b', workflowStatus: 'success' }),
+          ],
+        }),
+      ]);
+
+      expect(app.readyToMergePrs()).toHaveLength(2);
+
+      app.selectedOrg.set('org-a');
+
+      expect(app.readyToMergePrs()).toHaveLength(1);
+      expect(app.readyToMergePrs()[0].id).toBe(1);
     });
   });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -16,13 +16,14 @@ import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { OrgSwitcherComponent } from './components/org-switcher/org-switcher.component';
 import { PrGroupComponent } from './components/pr-group/pr-group.component';
 import { OverviewPanelComponent } from './components/overview-panel/overview-panel.component';
+import { FilterBarComponent, GroupSort, StatusFilter } from './components/filter-bar/filter-bar.component';
 import { getSourceRepositoryUrl } from './config/source-repository-url';
 import { SessionStorageService, SESSION_KEYS } from './services/session-storage.service';
 import { GitHubSearchService } from './services/github-search.service';
 
 @Component({
   selector: 'app-root',
-  imports: [SidebarComponent, OrgSwitcherComponent, PrGroupComponent, OverviewPanelComponent],
+  imports: [SidebarComponent, OrgSwitcherComponent, PrGroupComponent, OverviewPanelComponent, FilterBarComponent],
   templateUrl: './app.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -45,6 +46,12 @@ export class App {
   expandedGroupTitles = signal<Set<string>>(new Set());
   expandedPrIds = signal<Set<number>>(new Set());
   sidebarOpen = signal<boolean>(false);
+
+  // List controls (filter bar); filters narrow groups, they never hide PRs
+  // inside a matching group.
+  searchFilter = signal<string>('');
+  statusFilter = signal<StatusFilter>('all');
+  sortBy = signal<GroupSort>('failures');
 
   // Monotonic counter identifying the latest search. Searches can now overlap
   // (auto-search on load, refresh button, connection edits), so results from a
@@ -104,6 +111,45 @@ export class App {
       })
       .filter(group => group.prs.length > 0);
   });
+
+  /** visibleGroups further narrowed and ordered by the filter bar. */
+  filteredGroups = computed<PrGroup[]>(() => {
+    let groups = this.visibleGroups();
+
+    const query = this.searchFilter().trim().toLowerCase();
+    if (query) {
+      groups = groups.filter(group =>
+        group.title.toLowerCase().includes(query) ||
+        group.prs.some(pr => `${pr.repoOwner}/${pr.repoName}`.toLowerCase().includes(query)),
+      );
+    }
+
+    const status = this.statusFilter();
+    if (status !== 'all') {
+      groups = groups.filter(group => group.prs.some(pr => pr.workflowStatus === status));
+    }
+
+    const sortBy = this.sortBy();
+    return [...groups].sort((a, b) => {
+      switch (sortBy) {
+        case 'failures':
+          return b.workflowSummary.failed - a.workflowSummary.failed;
+        case 'prs':
+          return b.prs.length - a.prs.length;
+        case 'name':
+          return a.title.localeCompare(b.title);
+      }
+    });
+  });
+
+  /** Visible PRs whose workflows all passed — candidates for one-click merge. */
+  readyToMergePrs = computed(() =>
+    this.visibleGroups().flatMap(group => group.prs).filter(pr => pr.workflowStatus === 'success'),
+  );
+
+  isBulkProcessing = computed(() =>
+    this.visibleGroups().some(group => group.prs.some(pr => pr.isProcessing)),
+  );
 
   constructor() {
     effect(() => {
@@ -472,6 +518,19 @@ export class App {
       this.error.set(`Failed to merge PR #${prToUpdate.number}: ${message}`);
       this.setPrProcessingState(prToUpdate, false);
     }
+  }
+
+  /** Approve and merge every visible PR whose workflows passed. */
+  async mergeAllReady() {
+    const prsSnapshot = [...this.readyToMergePrs()];
+    for (const pr of prsSnapshot) {
+      await this.approveAndMergePullRequest(pr);
+    }
+  }
+
+  clearFilters(): void {
+    this.searchFilter.set('');
+    this.statusFilter.set('all');
   }
 
   async closeGroupPullRequests(group: PrGroup) {

--- a/src/app/components/filter-bar/filter-bar.component.html
+++ b/src/app/components/filter-bar/filter-bar.component.html
@@ -1,0 +1,61 @@
+<div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+
+  <div class="flex items-center gap-2">
+    <h3 class="text-sm font-semibold text-ink">PR Groups</h3>
+    <span class="text-[13px] text-ink-3 tabular-nums">Showing {{ resultCount() }} of {{ totalCount() }}</span>
+  </div>
+
+  <div class="flex flex-wrap items-center gap-2">
+
+    <!-- Search -->
+    <div class="relative">
+      <svg class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <circle cx="11" cy="11" r="8"/>
+        <path stroke-linecap="round" d="M21 21l-4.35-4.35"/>
+      </svg>
+      <input
+        type="text"
+        [value]="searchText()"
+        (input)="onSearchInput($event)"
+        placeholder="Search groups or repos…"
+        aria-label="Search PR groups or repositories"
+        class="h-9 w-full sm:w-64 rounded-md border border-edge bg-panel pl-9 pr-3 text-[13px] text-ink placeholder:text-ink-3 transition-all focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
+      />
+    </div>
+
+    <!-- Status segmented control -->
+    <div class="flex items-center rounded-md border border-edge bg-panel p-[3px]" role="group" aria-label="Filter by workflow status">
+      @for (tab of statusTabs; track tab.value) {
+        <button
+          type="button"
+          (click)="status.set(tab.value)"
+          [attr.aria-pressed]="status() === tab.value"
+          class="flex items-center gap-1.5 rounded px-3 py-[5px] text-xs font-medium transition-all"
+          [class.bg-accent]="status() === tab.value"
+          [class.text-white]="status() === tab.value"
+          [class.shadow-sm]="status() === tab.value"
+          [class.text-ink-2]="status() !== tab.value"
+          [class.hover:text-ink]="status() !== tab.value"
+        >
+          @if (tab.dot) {
+            <span class="h-1.5 w-1.5 rounded-full" [class]="status() === tab.value ? 'bg-white' : tab.dot" aria-hidden="true"></span>
+          }
+          {{ tab.label }}
+        </button>
+      }
+    </div>
+
+    <!-- Sort -->
+    <select
+      [value]="sortBy()"
+      (change)="onSortChange($event)"
+      aria-label="Sort PR groups"
+      class="h-9 rounded-md border border-edge bg-panel px-3 pr-8 text-[13px] text-ink cursor-pointer transition-colors hover:border-edge-2 focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
+    >
+      <option value="failures">Sort by failures</option>
+      <option value="prs">Sort by PR count</option>
+      <option value="name">Sort by name</option>
+    </select>
+
+  </div>
+</div>

--- a/src/app/components/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/components/filter-bar/filter-bar.component.spec.ts
@@ -1,0 +1,63 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FilterBarComponent } from './filter-bar.component';
+
+describe('FilterBarComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FilterBarComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+  });
+
+  it('shows the result counts', () => {
+    const fixture = TestBed.createComponent(FilterBarComponent);
+    fixture.componentRef.setInput('resultCount', 3);
+    fixture.componentRef.setInput('totalCount', 10);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Showing 3 of 10');
+  });
+
+  it('updates searchText as the user types', () => {
+    const fixture = TestBed.createComponent(FilterBarComponent);
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    input.value = 'ruby';
+    input.dispatchEvent(new Event('input'));
+
+    expect(fixture.componentInstance.searchText()).toBe('ruby');
+  });
+
+  it('sets the status when a segmented-control tab is clicked', () => {
+    const fixture = TestBed.createComponent(FilterBarComponent);
+    fixture.detectChanges();
+
+    const failedTab = Array.from(fixture.nativeElement.querySelectorAll('button')).find(
+      b => (b as HTMLButtonElement).textContent?.includes('Failed')) as HTMLButtonElement;
+    failedTab.click();
+
+    expect(fixture.componentInstance.status()).toBe('failure');
+  });
+
+  it('marks the active tab with aria-pressed', () => {
+    const fixture = TestBed.createComponent(FilterBarComponent);
+    fixture.detectChanges();
+
+    const pressed = fixture.nativeElement.querySelectorAll('button[aria-pressed="true"]');
+    expect(pressed).toHaveLength(1);
+    expect(pressed[0].textContent).toContain('All');
+  });
+
+  it('updates sortBy when the select changes', () => {
+    const fixture = TestBed.createComponent(FilterBarComponent);
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    select.value = 'name';
+    select.dispatchEvent(new Event('change'));
+
+    expect(fixture.componentInstance.sortBy()).toBe('name');
+  });
+});

--- a/src/app/components/filter-bar/filter-bar.component.ts
+++ b/src/app/components/filter-bar/filter-bar.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, input, model } from '@angular/core';
+
+export type StatusFilter = 'all' | 'success' | 'pending' | 'failure';
+export type GroupSort = 'failures' | 'prs' | 'name';
+
+/**
+ * Controls for the PR group list: text search, a workflow-status segmented
+ * control, and a sort selector, with a "Showing X of Y" result count.
+ */
+@Component({
+  selector: 'app-filter-bar',
+  templateUrl: './filter-bar.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FilterBarComponent {
+  searchText = model('');
+  status = model<StatusFilter>('all');
+  sortBy = model<GroupSort>('failures');
+
+  resultCount = input(0);
+  totalCount = input(0);
+
+  readonly statusTabs: { value: StatusFilter; label: string; dot?: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'success', label: 'Passed', dot: 'bg-emerald-500' },
+    { value: 'pending', label: 'Running', dot: 'bg-amber-400' },
+    { value: 'failure', label: 'Failed', dot: 'bg-rose-500' },
+  ];
+
+  onSearchInput(event: Event): void {
+    this.searchText.set((event.target as HTMLInputElement).value);
+  }
+
+  onSortChange(event: Event): void {
+    this.sortBy.set((event.target as HTMLSelectElement).value as GroupSort);
+  }
+}

--- a/src/app/components/pr-group/pr-group.component.html
+++ b/src/app/components/pr-group/pr-group.component.html
@@ -1,4 +1,5 @@
-<div class="rounded-lg border border-edge bg-panel overflow-hidden">
+<!-- Rendered as a row inside the app's single bordered, divided container -->
+<div>
 
   <!-- Group Header -->
   <div class="px-4 py-3 flex flex-wrap items-center gap-3 justify-between">

--- a/src/app/components/pr-item/pr-item.component.html
+++ b/src/app/components/pr-item/pr-item.component.html
@@ -80,6 +80,19 @@
     }
   </div>
 
+  <!-- Checks progress + age -->
+  <div class="hidden md:flex items-center gap-4 shrink-0 text-xs text-ink-3">
+    @if (checksTotal() > 0) {
+      <div class="flex items-center gap-2" [title]="checksPassed() + ' of ' + checksTotal() + ' checks passed'">
+        <div class="h-1.5 w-16 overflow-hidden rounded-full bg-matte/60" aria-hidden="true">
+          <div class="h-full rounded-full transition-all" [class]="progressColor()" [style.width.%]="checksPct()"></div>
+        </div>
+        <span class="tabular-nums">{{ checksPassed() }}/{{ checksTotal() }}</span>
+      </div>
+    }
+    <span class="tabular-nums" [title]="'Opened ' + pr().created_at">{{ age() }}</span>
+  </div>
+
   <!-- Action Buttons -->
   <div class="flex items-center justify-end gap-2 shrink-0">
     <button

--- a/src/app/components/pr-item/pr-item.component.spec.ts
+++ b/src/app/components/pr-item/pr-item.component.spec.ts
@@ -146,4 +146,62 @@ describe('PrItemComponent', () => {
       expect(fixture.componentInstance.formatConclusion(null)).toBe('Pending');
     });
   });
+
+  describe('checks progress', () => {
+    function makeCheck(id: number, conclusion: 'success' | 'failure' | 'skipped' | 'neutral' | null) {
+      return { id, name: `check-${id}`, status: 'completed' as const, conclusion, html_url: '' };
+    }
+
+    it('counts success, skipped, and neutral conclusions as passed', () => {
+      const fixture = TestBed.createComponent(PrItemComponent);
+      fixture.componentRef.setInput('pr', makePr({
+        checkRuns: [
+          makeCheck(1, 'success'),
+          makeCheck(2, 'skipped'),
+          makeCheck(3, 'neutral'),
+          makeCheck(4, 'failure'),
+          makeCheck(5, null),
+        ],
+      }));
+
+      expect(fixture.componentInstance.checksPassed()).toBe(3);
+      expect(fixture.componentInstance.checksTotal()).toBe(5);
+      expect(fixture.componentInstance.checksPct()).toBe(60);
+    });
+
+    it('renders the passed/total counter when checks exist and hides it otherwise', () => {
+      const fixture = TestBed.createComponent(PrItemComponent);
+      fixture.componentRef.setInput('pr', makePr({
+        workflowStatus: 'failure',
+        checkRuns: [makeCheck(1, 'success'), makeCheck(2, 'failure')],
+      }));
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('1/2');
+      expect(fixture.nativeElement.querySelector('[title*="checks passed"]')).not.toBeNull();
+
+      fixture.componentRef.setInput('pr', makePr({ checkRuns: [] }));
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[title*="checks passed"]')).toBeNull();
+    });
+  });
+
+  describe('age', () => {
+    it('formats the PR age compactly', () => {
+      const fixture = TestBed.createComponent(PrItemComponent);
+
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      fixture.componentRef.setInput('pr', makePr({ created_at: twoHoursAgo }));
+      expect(fixture.componentInstance.age()).toBe('2h');
+
+      const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      fixture.componentRef.setInput('pr', makePr({ created_at: threeDaysAgo }));
+      expect(fixture.componentInstance.age()).toBe('3d');
+    });
+
+    it('returns an empty string for an unparsable date', () => {
+      const fixture = TestBed.createComponent(PrItemComponent);
+      fixture.componentRef.setInput('pr', makePr({ created_at: 'not-a-date' }));
+      expect(fixture.componentInstance.age()).toBe('');
+    });
+  });
 });

--- a/src/app/components/pr-item/pr-item.component.ts
+++ b/src/app/components/pr-item/pr-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { CiStatus, CheckRun, PullRequest } from '../../models/pull-request.model';
 
 @Component({
@@ -19,6 +19,42 @@ export class PrItemComponent {
   get isMergeDisabled(): boolean {
     return this.pr().isProcessing || this.pr().workflowStatus === 'failure';
   }
+
+  checksTotal = computed(() => this.pr().checkRuns.length);
+
+  checksPassed = computed(() =>
+    this.pr().checkRuns.filter(
+      cr => cr.conclusion === 'success' || cr.conclusion === 'skipped' || cr.conclusion === 'neutral',
+    ).length,
+  );
+
+  checksPct = computed(() =>
+    this.checksTotal() > 0 ? Math.round((this.checksPassed() / this.checksTotal()) * 100) : 0,
+  );
+
+  progressColor = computed(() => {
+    switch (this.pr().workflowStatus) {
+      case 'success': return 'bg-emerald-500';
+      case 'pending': return 'bg-amber-400';
+      case 'failure': return 'bg-rose-500';
+      default: return 'bg-ink-3';
+    }
+  });
+
+  /** Compact age like "5m", "3h", "2d", "1mo". */
+  age = computed(() => {
+    const created = new Date(this.pr().created_at).getTime();
+    if (Number.isNaN(created)) return '';
+    const minutes = Math.max(0, Math.floor((Date.now() - created) / 60_000));
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d`;
+    const months = Math.floor(days / 30);
+    if (months < 12) return `${months}mo`;
+    return `${Math.floor(months / 12)}y`;
+  });
 
   onClosePr(): void {
     this.closePr.emit(this.pr());


### PR DESCRIPTION
Final phase of the UI redesign (#76): the filter bar, the demo's unified group list, PR-row polish, and the ready-to-merge callout.

## What changed

- **Filter bar** (`FilterBarComponent`, `model()`-based two-way bindings): text search matching group titles *and* `owner/repo` names, an **All / Passed / Running / Failed** segmented control, a sort select (**failures-first** default, PR count, name), and "Showing X of Y". Filters narrow which groups are listed — they never hide PRs inside a matching group (same semantics as the demo). Layered on top of the phase 2 org filter via a `filteredGroups` computed.
- **Unified group list**: groups are now rows in a single bordered `divide-y` container instead of separate stacked cards — noticeably denser with many groups. Group headers (status dots, PR-count badge, Close All / Approve & Merge All) are unchanged.
- **PR-row polish**: each row gains a check-runs **progress bar + passed/total counter** (colored by workflow status; `skipped`/`neutral` count as passed, matching the existing aggregate logic) and a compact **age** (5m / 3h / 2d / 1mo). Both derive from data already fetched. The expandable check-run detail view is untouched.
- **Ready-to-merge callout**: when visible PRs have all workflows passing, a banner shows "N pull requests are ready to merge — Merge All Ready", running the existing approve-and-merge flow over exactly those PRs. It respects the active org filter, and the button disables while any PR is processing.
- **Filtered empty state** with a "Clear filters" button, distinct from the no-results and no-orgs states.

## Test note

While adding the filter tests I found existing tests that use the real `SessionStorageService` were leaking `connections`/`selectedOrg` into jsdom's shared `sessionStorage`, polluting later tests (my new tests failed until I traced it). The App suite now clears `sessionStorage` in `beforeEach`/`afterEach`.

## Tests

15 new tests: filter-bar interactions (search/status/sort/aria-pressed/counts), `filteredGroups` (title + repo search, status gating, all three sorts, org-filter layering, clearFilters), `mergeAllReady`/`readyToMergePrs` (only passing PRs merged; org-scoped), PR-item checks progress and age formatting. `npm run lint`, `npm test` (160 tests), and `npm run build` all pass.

Verified in the browser with seeded data: board layout with tiles + callout + filter bar, expanded groups with progress bars and ages, Failed-tab filtering ("Showing 2 of 3"), and the no-match empty state with Clear filters.

Closes #76 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)
