### PR TITLE
Connection model v2: GitHub Enterprise Server support

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,9 +13,9 @@
   <app-sidebar [groupCount]="visibleGroups().length" [mobileOpen]="sidebarOpen()">
     <app-org-switcher
       [connections]="connections()"
-      [selectedOrg]="selectedOrg()"
+      [selectedKey]="selectedOrgKey()"
       (connectionsChange)="onConnectionsChange($event)"
-      (selectedOrgChange)="onSelectedOrgChange($event)">
+      (selectedKeyChange)="onSelectedOrgChange($event)">
     </app-org-switcher>
   </app-sidebar>
 
@@ -239,9 +239,9 @@
             <svg class="w-10 h-10 mx-auto mb-3 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
             </svg>
-            @if (prGroups().length > 0 && selectedOrg()) {
+            @if (prGroups().length > 0 && selectedConnection(); as selected) {
               <!-- PRs exist, just none for the active org filter -->
-              <p class="text-sm">No open Renovate PRs found for {{ selectedOrg() }}.</p>
+              <p class="text-sm">No open Renovate PRs found for {{ selected.organization }}.</p>
               <button
                 type="button"
                 (click)="onSelectedOrgChange(null)"

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -3,13 +3,26 @@ import { TestBed } from '@angular/core/testing';
 import { vi } from 'vitest';
 import { App } from './app';
 import { getSourceRepositoryUrl } from './config/source-repository-url';
-import { PullRequest, PrGroup } from './models/pull-request.model';
+import { PullRequest, PrGroup, OrgConnection, DEFAULT_GITHUB_HOST, connectionKey } from './models/pull-request.model';
 import { SessionStorageService } from './services/session-storage.service';
 import { GitHubProviderService } from './services/github-provider.service';
 
+function conn(organization: string, token: string): OrgConnection {
+  return { platform: 'github', host: DEFAULT_GITHUB_HOST, organization, token };
+}
+
+/** Canonical connection key for a default-host GitHub org. */
+function orgKey(organization: string): string {
+  return connectionKey({ platform: 'github', host: DEFAULT_GITHUB_HOST, organization });
+}
+
 function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  const id = overrides.id ?? 1;
   return {
-    id: 1,
+    id,
+    uid: `github|https://github.com|${id}`,
+    platform: 'github',
+    host: 'https://github.com',
     number: 1,
     title: 'Update dependency foo to v2',
     html_url: 'https://github.com/org/repo/pull/1',
@@ -139,28 +152,28 @@ describe('App', () => {
 
     it('is true when at least one connection is configured', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.connections.set([{ organization: 'my-org', token: 'ghp_token' }]);
+      app.connections.set([conn('my-org', 'ghp_token')]);
       expect(app.formValid()).toBe(true);
     });
 
     it('is true when multiple connections are configured', () => {
       const app = TestBed.createComponent(App).componentInstance;
       app.connections.set([
-        { organization: 'org-a', token: 'ghp_aaa' },
-        { organization: 'org-b', token: 'ghp_bbb' },
+        conn('org-a', 'ghp_aaa'),
+        conn('org-b', 'ghp_bbb'),
       ]);
       expect(app.formValid()).toBe(true);
     });
 
     it('is false when the only connection has an empty token', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.connections.set([{ organization: 'my-org', token: '' }]);
+      app.connections.set([conn('my-org', '')]);
       expect(app.formValid()).toBe(false);
     });
 
     it('is false when the only connection has a whitespace-only org', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.connections.set([{ organization: '   ', token: 'ghp_token' }]);
+      app.connections.set([conn('   ', 'ghp_token')]);
       expect(app.formValid()).toBe(false);
     });
   });
@@ -243,11 +256,11 @@ describe('App', () => {
       const app = TestBed.createComponent(App).componentInstance;
       const pr = makePr({ id: 42 });
       app.prGroups.set([makeGroup({ prs: [pr] })]);
-      app.expandedPrIds.set(new Set([42]));
+      app.expandedPrIds.set(new Set([pr.uid]));
 
       app.removePrFromGroup(pr);
 
-      expect(app.expandedPrIds().has(42)).toBe(false);
+      expect(app.expandedPrIds().has(pr.uid)).toBe(false);
     });
   });
 
@@ -269,28 +282,30 @@ describe('App', () => {
       const group = makeGroup({ prs: [pr] });
       app.prGroups.set([group]);
       app.expandedGroupTitles.set(new Set([group.title]));
-      app.expandedPrIds.set(new Set([7]));
+      app.expandedPrIds.set(new Set([pr.uid]));
 
       app.toggleGroup(group);
 
       expect(app.expandedGroupTitles().has(group.title)).toBe(false);
       expect(app.visibleGroups()[0].isExpanded).toBe(false);
-      expect(app.expandedPrIds().has(7)).toBe(false);
+      expect(app.expandedPrIds().has(pr.uid)).toBe(false);
     });
   });
 
   describe('togglePullRequest', () => {
-    it('adds the PR id to expandedPrIds when not present', () => {
+    it('adds the PR uid to expandedPrIds when not present', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.togglePullRequest(makePr({ id: 5 }));
-      expect(app.expandedPrIds().has(5)).toBe(true);
+      const pr = makePr({ id: 5 });
+      app.togglePullRequest(pr);
+      expect(app.expandedPrIds().has(pr.uid)).toBe(true);
     });
 
-    it('removes the PR id from expandedPrIds when already present', () => {
+    it('removes the PR uid from expandedPrIds when already present', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.expandedPrIds.set(new Set([5]));
-      app.togglePullRequest(makePr({ id: 5 }));
-      expect(app.expandedPrIds().has(5)).toBe(false);
+      const pr = makePr({ id: 5 });
+      app.expandedPrIds.set(new Set([pr.uid]));
+      app.togglePullRequest(pr);
+      expect(app.expandedPrIds().has(pr.uid)).toBe(false);
     });
   });
 
@@ -337,7 +352,7 @@ describe('App', () => {
   describe('search incomplete results (through the real provider)', () => {
     it('surfaces incompleteResults warning signal after searchAndProcessPullRequests', async () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.connections.set([{ organization: 'my-org', token: 'ghp_test' }]);
+      app.connections.set([conn('my-org', 'ghp_test')]);
 
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         new Response(JSON.stringify({ total_count: 1, incomplete_results: true, items: [] }), { status: 200 })
@@ -360,8 +375,8 @@ describe('App', () => {
 
       const app = TestBed.createComponent(App).componentInstance;
       app.connections.set([
-        { organization: 'org-a', token: 'a' },
-        { organization: 'org-b', token: 'b' },
+        conn('org-a', 'a'),
+        conn('org-b', 'b'),
       ]);
 
       await app.searchAndProcessPullRequests();
@@ -377,7 +392,7 @@ describe('App', () => {
       TestBed.overrideProvider(GitHubProviderService, { useValue: provider });
 
       const app = TestBed.createComponent(App).componentInstance;
-      app.connections.set([{ organization: 'org-a', token: 'a' }]);
+      app.connections.set([conn('org-a', 'a')]);
 
       await app.searchAndProcessPullRequests();
 
@@ -393,14 +408,14 @@ describe('App', () => {
       const app = TestBed.createComponent(App).componentInstance;
       // A malformed entry (empty token) slips into the signal directly.
       app.connections.set([
-        { organization: 'good-org', token: 'ghp_good' },
-        { organization: 'bad-org', token: '' },
+        conn('good-org', 'ghp_good'),
+        conn('bad-org', ''),
       ]);
 
       await app.searchAndProcessPullRequests();
 
       expect(provider.searchRenovatePrs).toHaveBeenCalledTimes(1);
-      expect(provider.searchRenovatePrs).toHaveBeenCalledWith({ organization: 'good-org', token: 'ghp_good' });
+      expect(provider.searchRenovatePrs).toHaveBeenCalledWith(conn('good-org', 'ghp_good'));
     });
   });
 
@@ -476,7 +491,7 @@ describe('App', () => {
   describe('layout chrome', () => {
     it('shows the org name in the sidebar switcher for a single connection', () => {
       const fixture = TestBed.createComponent(App);
-      fixture.componentInstance.connections.set([{ organization: 'my-org', token: 'ghp_test' }]);
+      fixture.componentInstance.connections.set([conn('my-org', 'ghp_test')]);
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toContain('my-org');
       expect(fixture.nativeElement.textContent).toContain('github.com');
@@ -485,8 +500,8 @@ describe('App', () => {
     it('shows "All organizations" in the sidebar switcher for multiple connections', () => {
       const fixture = TestBed.createComponent(App);
       fixture.componentInstance.connections.set([
-        { organization: 'org-a', token: 'ghp_aaa' },
-        { organization: 'org-b', token: 'ghp_bbb' },
+        conn('org-a', 'ghp_aaa'),
+        conn('org-b', 'ghp_bbb'),
       ]);
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toContain('All organizations');
@@ -518,12 +533,12 @@ describe('App', () => {
 
     it('updates the subtitle with the configured org', () => {
       const app = TestBed.createComponent(App).componentInstance;
-      app.connections.set([{ organization: 'my-org', token: 'ghp_test' }]);
+      app.connections.set([conn('my-org', 'ghp_test')]);
       expect(app.subtitle()).toContain('the my-org organization');
 
       app.connections.set([
-        { organization: 'org-a', token: 'a' },
-        { organization: 'org-b', token: 'b' },
+        conn('org-a', 'a'),
+        conn('org-b', 'b'),
       ]);
       expect(app.subtitle()).toContain('2 GitHub organizations');
     });
@@ -539,7 +554,7 @@ describe('App', () => {
       TestBed.createComponent(App);
 
       expect(search.searchRenovatePrs).toHaveBeenCalledWith(
-        { organization: 'saved-org', token: 'ghp_saved' });
+        conn('saved-org', 'ghp_saved'));
     });
 
     it('does not search on startup when no connections are stored', () => {
@@ -556,10 +571,10 @@ describe('App', () => {
       TestBed.overrideProvider(SessionStorageService, { useValue: makeStorageSpy() });
 
       const app = TestBed.createComponent(App).componentInstance;
-      app.onConnectionsChange([{ organization: 'new-org', token: 'ghp_new' }]);
+      app.onConnectionsChange([conn('new-org', 'ghp_new')]);
 
       expect(search.searchRenovatePrs).toHaveBeenCalledWith(
-        { organization: 'new-org', token: 'ghp_new' });
+        conn('new-org', 'ghp_new'));
     });
 
     it('clears results and ignores the in-flight search when the last org is removed', async () => {
@@ -599,7 +614,7 @@ describe('App', () => {
       TestBed.overrideProvider(GitHubProviderService, { useValue: provider });
 
       const app = TestBed.createComponent(App).componentInstance;
-      app.connections.set([{ organization: 'my-org', token: 'ghp_test' }]);
+      app.connections.set([conn('my-org', 'ghp_test')]);
 
       const first = app.searchAndProcessPullRequests();
       const second = app.searchAndProcessPullRequests();
@@ -617,8 +632,8 @@ describe('App', () => {
   describe('per-org views', () => {
     function seedTwoOrgGroups(app: App) {
       app.connections.set([
-        { organization: 'org-a', token: 'a' },
-        { organization: 'org-b', token: 'b' },
+        conn('org-a', 'a'),
+        conn('org-b', 'b'),
       ]);
       app.prGroups.set([
         makeGroup({
@@ -648,7 +663,7 @@ describe('App', () => {
       const app = TestBed.createComponent(App).componentInstance;
       seedTwoOrgGroups(app);
 
-      app.selectedOrg.set('org-a');
+      app.selectedOrgKey.set(orgKey('org-a'));
 
       const groups = app.visibleGroups();
       expect(groups).toHaveLength(1);
@@ -660,7 +675,7 @@ describe('App', () => {
       const app = TestBed.createComponent(App).componentInstance;
       seedTwoOrgGroups(app);
 
-      app.selectedOrg.set('ORG-A');
+      app.selectedOrgKey.set(orgKey('ORG-A'));
 
       expect(app.visibleGroups()).toHaveLength(1);
     });
@@ -673,7 +688,7 @@ describe('App', () => {
       expect(app.visibleGroups()[0].aggregateCiStatus).toBe('failure');
       expect(app.visibleGroups()[0].workflowSummary).toEqual({ success: 1, pending: 0, failed: 1 });
 
-      app.selectedOrg.set('org-a');
+      app.selectedOrgKey.set(orgKey('org-a'));
 
       expect(app.visibleGroups()[0].aggregateCiStatus).toBe('success');
       expect(app.visibleGroups()[0].workflowSummary).toEqual({ success: 1, pending: 0, failed: 0 });
@@ -685,18 +700,42 @@ describe('App', () => {
 
       expect(app.visibleConnections()).toHaveLength(2);
 
-      app.selectedOrg.set('org-b');
+      app.selectedOrgKey.set(orgKey('org-b'));
 
-      expect(app.visibleConnections()).toEqual([{ organization: 'org-b', token: 'b' }]);
+      expect(app.visibleConnections()).toEqual([conn('org-b', 'b')]);
     });
 
     it('names the selected org in the subtitle', () => {
       const app = TestBed.createComponent(App).componentInstance;
       seedTwoOrgGroups(app);
 
-      app.selectedOrg.set('org-a');
+      app.selectedOrgKey.set(orgKey('org-a'));
 
       expect(app.subtitle()).toContain('the org-a organization');
+    });
+
+    it('distinguishes same-named orgs on different hosts', () => {
+      const app = TestBed.createComponent(App).componentInstance;
+      const ghesHost = 'https://ghes.example.com';
+      app.connections.set([
+        conn('my-org', 'a'),
+        { ...conn('my-org', 'b'), host: ghesHost },
+      ]);
+      app.prGroups.set([
+        makeGroup({
+          prs: [
+            makePr({ id: 1, repoOwner: 'my-org' }), // github.com (makePr default)
+            makePr({ id: 2, repoOwner: 'my-org', host: ghesHost, uid: `github|${ghesHost}|2` }),
+          ],
+        }),
+      ]);
+
+      app.selectedOrgKey.set(connectionKey({ platform: 'github', host: ghesHost, organization: 'my-org' }));
+
+      const groups = app.visibleGroups();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].prs.map(pr => pr.id)).toEqual([2]);
+      expect(app.visibleConnections()).toEqual([{ ...conn('my-org', 'b'), host: ghesHost }]);
     });
 
     it('onSelectedOrgChange persists the selection', () => {
@@ -705,9 +744,9 @@ describe('App', () => {
 
       const app = TestBed.createComponent(App).componentInstance;
 
-      app.onSelectedOrgChange('org-a');
-      expect(app.selectedOrg()).toBe('org-a');
-      expect(storageSpy.set).toHaveBeenCalledWith('selectedOrg', 'org-a');
+      app.onSelectedOrgChange(orgKey('org-a'));
+      expect(app.selectedOrgKey()).toBe(orgKey('org-a'));
+      expect(storageSpy.set).toHaveBeenCalledWith('selectedOrg', orgKey('org-a'));
 
       app.onSelectedOrgChange(null);
       expect(storageSpy.set).toHaveBeenCalledWith('selectedOrg', '');
@@ -716,24 +755,24 @@ describe('App', () => {
     it('restores a persisted selection that matches a configured org', () => {
       stubSearchService();
       const storageSpy = makeStorageSpy(
-        [{ organization: 'Org-A', token: 'a' }], '', '', 'org-a');
+        [conn('Org-A', 'a')], '', '', 'org-a');
       TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
 
       const app = TestBed.createComponent(App).componentInstance;
 
       // Restored with the connection's canonical casing.
-      expect(app.selectedOrg()).toBe('Org-A');
+      expect(app.selectedOrgKey()).toBe(orgKey('Org-A'));
     });
 
     it('ignores a persisted selection that no longer matches any connection', () => {
       stubSearchService();
       const storageSpy = makeStorageSpy(
-        [{ organization: 'org-a', token: 'a' }], '', '', 'gone-org');
+        [conn('org-a', 'a')], '', '', 'gone-org');
       TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
 
       const app = TestBed.createComponent(App).componentInstance;
 
-      expect(app.selectedOrg()).toBeNull();
+      expect(app.selectedOrgKey()).toBeNull();
     });
 
     it('resets the selection when the selected org is removed', () => {
@@ -743,28 +782,28 @@ describe('App', () => {
 
       const app = TestBed.createComponent(App).componentInstance;
       app.onConnectionsChange([
-        { organization: 'org-a', token: 'a' },
-        { organization: 'org-b', token: 'b' },
+        conn('org-a', 'a'),
+        conn('org-b', 'b'),
       ]);
-      app.onSelectedOrgChange('org-b');
+      app.onSelectedOrgChange(orgKey('org-b'));
 
-      app.onConnectionsChange([{ organization: 'org-a', token: 'a' }]);
+      app.onConnectionsChange([conn('org-a', 'a')]);
 
-      expect(app.selectedOrg()).toBeNull();
+      expect(app.selectedOrgKey()).toBeNull();
     });
 
     it('keeps the selection when an unrelated org is removed', () => {
       stubSearchService();
       const app = TestBed.createComponent(App).componentInstance;
       app.onConnectionsChange([
-        { organization: 'org-a', token: 'a' },
-        { organization: 'org-b', token: 'b' },
+        conn('org-a', 'a'),
+        conn('org-b', 'b'),
       ]);
-      app.onSelectedOrgChange('org-a');
+      app.onSelectedOrgChange(orgKey('org-a'));
 
-      app.onConnectionsChange([{ organization: 'org-a', token: 'a' }]);
+      app.onConnectionsChange([conn('org-a', 'a')]);
 
-      expect(app.selectedOrg()).toBe('org-a');
+      expect(app.selectedOrgKey()).toBe(orgKey('org-a'));
     });
   });
 
@@ -859,7 +898,7 @@ describe('App', () => {
         }),
       ]);
 
-      app.selectedOrg.set('org-b');
+      app.selectedOrgKey.set(orgKey('org-b'));
       app.statusFilter.set('failure');
 
       const groups = app.filteredGroups();
@@ -905,7 +944,7 @@ describe('App', () => {
 
       expect(app.readyToMergePrs()).toHaveLength(2);
 
-      app.selectedOrg.set('org-a');
+      app.selectedOrgKey.set(orgKey('org-a'));
 
       expect(app.readyToMergePrs()).toHaveLength(1);
       expect(app.readyToMergePrs()[0].id).toBe(1);
@@ -915,7 +954,7 @@ describe('App', () => {
   describe('sessionStorage persistence', () => {
     it('restores connections from session storage on init', () => {
       stubSearchService();
-      const saved = [{ organization: 'saved-org', token: 'saved-token' }];
+      const saved = [conn('saved-org', 'saved-token')];
       const storageSpy = makeStorageSpy(saved);
       TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
 
@@ -931,8 +970,8 @@ describe('App', () => {
 
       const app = TestBed.createComponent(App).componentInstance;
 
-      expect(app.connections()).toEqual([{ organization: 'legacy-org', token: 'legacy-token' }]);
-      expect(storageSpy.setJson).toHaveBeenCalledWith('connections', [{ organization: 'legacy-org', token: 'legacy-token' }]);
+      expect(app.connections()).toEqual([conn('legacy-org', 'legacy-token')]);
+      expect(storageSpy.setJson).toHaveBeenCalledWith('connections', [conn('legacy-org', 'legacy-token')]);
     });
 
     it('clears the legacy organization/token keys after migrating', () => {
@@ -952,7 +991,7 @@ describe('App', () => {
       TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
 
       const app = TestBed.createComponent(App).componentInstance;
-      const newConnections = [{ organization: 'my-org', token: 'ghp_test' }];
+      const newConnections = [conn('my-org', 'ghp_test')];
       app.onConnectionsChange(newConnections);
 
       expect(storageSpy.setJson).toHaveBeenCalledWith('connections', newConnections);
@@ -979,11 +1018,48 @@ describe('App', () => {
       expect(storageSpy.setJson).not.toHaveBeenCalled();
     });
 
+    it('defaults platform and host for connections stored before multi-platform support', () => {
+      stubSearchService();
+      // Old shape: no platform, host, or renovateAuthor.
+      const storageSpy = makeStorageSpy([{ organization: 'old-org', token: 'old-token' }]);
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      expect(app.connections()).toEqual([conn('old-org', 'old-token')]);
+    });
+
+    it('allows the same org name on different hosts', () => {
+      stubSearchService();
+      const ghes = { ...conn('my-org', 't2'), host: 'https://ghes.example.com' };
+      const storageSpy = makeStorageSpy([conn('my-org', 't1'), ghes]);
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      expect(app.connections()).toHaveLength(2);
+    });
+
+    it('normalizes hosts and drops entries with unparsable ones', () => {
+      stubSearchService();
+      const storageSpy = makeStorageSpy([
+        { ...conn('org-a', 't1'), host: 'https://ghes.example.com/' }, // trailing slash
+        { ...conn('org-b', 't2'), host: 'not a url' },
+      ]);
+      TestBed.overrideProvider(SessionStorageService, { useValue: storageSpy });
+
+      const app = TestBed.createComponent(App).componentInstance;
+
+      expect(app.connections()).toEqual([
+        { ...conn('org-a', 't1'), host: 'https://ghes.example.com' },
+      ]);
+    });
+
     it('sanitizes stored connections: trims, drops invalid entries, and de-duplicates by org', () => {
       stubSearchService();
       const storageSpy = makeStorageSpy([
         { organization: '  org-a  ', token: '  t1  ' },
-        { organization: 'ORG-A', token: 't2' }, // case-insensitive duplicate
+        conn('ORG-A', 't2'), // case-insensitive duplicate
         { organization: '', token: 'no-org' },   // invalid: empty org
         { organization: 'org-b', token: '' },     // invalid: empty token
       ]);
@@ -991,7 +1067,7 @@ describe('App', () => {
 
       const app = TestBed.createComponent(App).componentInstance;
 
-      expect(app.connections()).toEqual([{ organization: 'org-a', token: 't1' }]);
+      expect(app.connections()).toEqual([conn('org-a', 't1')]);
     });
 
     it('sanitizes connections passed to onConnectionsChange before storing', () => {
@@ -1001,12 +1077,12 @@ describe('App', () => {
 
       const app = TestBed.createComponent(App).componentInstance;
       app.onConnectionsChange([
-        { organization: ' my-org ', token: ' ghp_test ' },
-        { organization: 'my-org', token: 'dupe' },
+        conn(' my-org ', ' ghp_test '),
+        conn('my-org', 'dupe'),
       ]);
 
-      expect(app.connections()).toEqual([{ organization: 'my-org', token: 'ghp_test' }]);
-      expect(storageSpy.setJson).toHaveBeenCalledWith('connections', [{ organization: 'my-org', token: 'ghp_test' }]);
+      expect(app.connections()).toEqual([conn('my-org', 'ghp_test')]);
+      expect(storageSpy.setJson).toHaveBeenCalledWith('connections', [conn('my-org', 'ghp_test')]);
     });
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -6,6 +6,10 @@ import {
   PrGroupData,
   PullRequest,
   CiStatus,
+  connectionKey,
+  normalizeHost,
+  prConnectionKey,
+  DEFAULT_GITHUB_HOST,
 } from './models/pull-request.model';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { OrgSwitcherComponent } from './components/org-switcher/org-switcher.component';
@@ -33,8 +37,9 @@ export class App {
 
   // --- STATE SIGNALS ---
   connections = signal<OrgConnection[]>(this.loadConnections());
-  // The active org filter: null shows every configured organization.
-  selectedOrg = signal<string | null>(this.loadSelectedOrg());
+  // The active org filter, as a canonical connection key (see connectionKey);
+  // null shows every configured organization.
+  selectedOrgKey = signal<string | null>(this.loadSelectedOrgKey());
   darkMode = signal<boolean>(this.getInitialDarkMode());
   prGroups = signal<PrGroupData[]>([]);
   isLoading = signal<boolean>(false);
@@ -42,7 +47,8 @@ export class App {
   incompleteResults = signal<boolean>(false);
   searched = signal<boolean>(false);
   expandedGroupTitles = signal<Set<string>>(new Set());
-  expandedPrIds = signal<Set<number>>(new Set());
+  // Keyed by PullRequest.uid — numeric ids are only unique per instance.
+  expandedPrIds = signal<Set<string>>(new Set());
   sidebarOpen = signal<boolean>(false);
 
   // List controls (filter bar); filters narrow groups, they never hide PRs
@@ -64,10 +70,17 @@ export class App {
     this.connections().some(c => c.organization.trim().length > 0 && c.token.trim().length > 0),
   );
 
+  /** The connection matching the active org filter, if any. */
+  selectedConnection = computed(() => {
+    const key = this.selectedOrgKey();
+    if (!key) return undefined;
+    return this.connections().find(c => connectionKey(c) === key);
+  });
+
   subtitle = computed(() => {
-    const selected = this.selectedOrg();
+    const selected = this.selectedConnection();
     if (selected) {
-      return `Monitor and manage Renovate pull requests across the ${selected} organization`;
+      return `Monitor and manage Renovate pull requests across the ${selected.organization} organization`;
     }
     const conns = this.connections();
     if (conns.length === 1) {
@@ -81,9 +94,9 @@ export class App {
 
   /** Connections narrowed to the active org filter (all of them when unfiltered). */
   visibleConnections = computed(() => {
-    const selected = this.selectedOrg()?.toLowerCase();
-    if (!selected) return this.connections();
-    return this.connections().filter(c => c.organization.toLowerCase() === selected);
+    const key = this.selectedOrgKey();
+    if (!key) return this.connections();
+    return this.connections().filter(c => connectionKey(c) === key);
   });
 
   /**
@@ -92,12 +105,12 @@ export class App {
    * counts and statuses always match what is on screen.
    */
   visibleGroups = computed<PrGroup[]>(() => {
-    const selected = this.selectedOrg()?.toLowerCase();
+    const key = this.selectedOrgKey();
     const expanded = this.expandedGroupTitles();
     return this.prGroups()
       .map(group => {
-        const prs = selected
-          ? group.prs.filter(pr => pr.repoOwner.toLowerCase() === selected)
+        const prs = key
+          ? group.prs.filter(pr => prConnectionKey(pr) === key)
           : group.prs;
         return {
           title: group.title,
@@ -173,9 +186,9 @@ export class App {
     this.connections.set(sanitized);
     this.storage.setJson(SESSION_KEYS.connections, sanitized);
 
-    // Reset the org filter if the selected org was just removed.
-    const selected = this.selectedOrg()?.toLowerCase();
-    if (selected && !sanitized.some(c => c.organization.toLowerCase() === selected)) {
+    // Reset the org filter if the selected connection was just removed.
+    const key = this.selectedOrgKey();
+    if (key && !sanitized.some(c => connectionKey(c) === key)) {
       this.onSelectedOrgChange(null);
     }
 
@@ -193,19 +206,21 @@ export class App {
     }
   }
 
-  onSelectedOrgChange(org: string | null): void {
-    this.selectedOrg.set(org);
-    this.storage.set(SESSION_KEYS.selectedOrg, org ?? '');
+  onSelectedOrgChange(key: string | null): void {
+    this.selectedOrgKey.set(key);
+    this.storage.set(SESSION_KEYS.selectedOrg, key ?? '');
   }
 
-  private loadSelectedOrg(): string | null {
+  private loadSelectedOrgKey(): string | null {
     const stored = this.storage.get(SESSION_KEYS.selectedOrg).trim();
     if (!stored) return null;
-    // Only honor a persisted selection that still matches a configured org.
+    // Only honor a persisted selection that still matches a configured
+    // connection. Sessions from before multi-host support stored the bare org
+    // name, so accept that form too.
     const match = this.connections().find(
-      c => c.organization.toLowerCase() === stored.toLowerCase(),
+      c => connectionKey(c) === stored || c.organization.toLowerCase() === stored.toLowerCase(),
     );
-    return match ? match.organization : null;
+    return match ? connectionKey(match) : null;
   }
 
   private loadConnections(): OrgConnection[] {
@@ -223,7 +238,9 @@ export class App {
     const org = this.storage.get(SESSION_KEYS.organization).trim();
     const token = this.storage.get(SESSION_KEYS.token).trim();
     if (org && token) {
-      const migrated: OrgConnection[] = [{ organization: org, token }];
+      const migrated: OrgConnection[] = [
+        { platform: 'github', host: DEFAULT_GITHUB_HOST, organization: org, token },
+      ];
       this.storage.setJson(SESSION_KEYS.connections, migrated);
       // Drop the now-migrated legacy keys so they don't linger for the session.
       this.storage.remove(SESSION_KEYS.organization);
@@ -234,7 +251,12 @@ export class App {
     return [];
   }
 
-  /** Trim, drop entries missing an org or token, and de-duplicate by org (case-insensitive). */
+  /**
+   * Trim, drop entries missing an org or token or with an unparsable host,
+   * normalize platform/host (connections stored before multi-platform support
+   * have neither — they default to github.com), and de-duplicate by the
+   * canonical connection key.
+   */
   private sanitizeConnections(connections: OrgConnection[]): OrgConnection[] {
     const seen = new Set<string>();
     const result: OrgConnection[] = [];
@@ -244,12 +266,27 @@ export class App {
       }
       const organization = c.organization.trim();
       const token = c.token.trim();
-      const key = organization.toLowerCase();
-      if (!organization || !token || seen.has(key)) {
+      if (!organization || !token) {
+        continue;
+      }
+
+      const platform = c.platform === 'gitlab' ? 'gitlab' : 'github';
+      const host = normalizeHost(typeof c.host === 'string' ? c.host : '');
+      if (!host) {
+        continue;
+      }
+      const renovateAuthor =
+        typeof c.renovateAuthor === 'string' && c.renovateAuthor.trim() ? c.renovateAuthor.trim() : undefined;
+
+      const normalized: OrgConnection = renovateAuthor
+        ? { platform, host, organization, token, renovateAuthor }
+        : { platform, host, organization, token };
+      const key = connectionKey(normalized);
+      if (seen.has(key)) {
         continue;
       }
       seen.add(key);
-      result.push({ organization, token });
+      result.push(normalized);
     }
     return result;
   }
@@ -450,13 +487,13 @@ export class App {
 
   removePrFromGroup(prToRemove: PullRequest) {
     const updatedGroups = this.prGroups()
-      .map(group => ({ ...group, prs: group.prs.filter(p => p.id !== prToRemove.id) }))
+      .map(group => ({ ...group, prs: group.prs.filter(p => p.uid !== prToRemove.uid) }))
       .filter(group => group.prs.length > 0); // Remove group if it becomes empty
     this.prGroups.set(updatedGroups);
 
-    if (this.expandedPrIds().has(prToRemove.id)) {
+    if (this.expandedPrIds().has(prToRemove.uid)) {
       const updated = new Set(this.expandedPrIds());
-      updated.delete(prToRemove.id);
+      updated.delete(prToRemove.uid);
       this.expandedPrIds.set(updated);
     }
   }
@@ -472,7 +509,7 @@ export class App {
       expanded.delete(group.title);
       // Collapse the group's PR detail panels along with it.
       const prIds = new Set(this.expandedPrIds());
-      group.prs.forEach(pr => prIds.delete(pr.id));
+      group.prs.forEach(pr => prIds.delete(pr.uid));
       this.expandedPrIds.set(prIds);
     } else {
       expanded.add(group.title);
@@ -482,10 +519,10 @@ export class App {
 
   togglePullRequest(pr: PullRequest) {
     const updated = new Set(this.expandedPrIds());
-    if (updated.has(pr.id)) {
-      updated.delete(pr.id);
+    if (updated.has(pr.uid)) {
+      updated.delete(pr.uid);
     } else {
-      updated.add(pr.id);
+      updated.add(pr.uid);
     }
     this.expandedPrIds.set(updated);
   }

--- a/src/app/components/org-switcher/org-switcher.component.html
+++ b/src/app/components/org-switcher/org-switcher.component.html
@@ -20,7 +20,7 @@
       </svg>
       <span class="truncate text-[13px] font-medium text-ink">{{ triggerLabel() }}</span>
     </span>
-    <span class="block text-[11px] text-ink-3">github.com</span>
+    <span class="block truncate text-[11px] text-ink-3">{{ triggerSublabel() }}</span>
   </span>
   <svg
     class="h-3.5 w-3.5 shrink-0 text-ink-3 transition-transform duration-200"
@@ -57,10 +57,10 @@
         @if (showSelection()) {
           <button
             type="button"
-            (click)="selectOrg(null)"
+            (click)="select(null)"
             class="flex w-full items-center gap-2.5 rounded-md px-2 py-2 transition-colors hover:bg-ghost focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            [class.bg-accent-subtle]="selectedOrg() === null"
-            [attr.aria-pressed]="selectedOrg() === null"
+            [class.bg-accent-subtle]="selectedKey() === null"
+            [attr.aria-pressed]="selectedKey() === null"
           >
             <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-ghost text-ink-3" aria-hidden="true">
               <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -74,7 +74,7 @@
               <span class="block truncate text-[13px] font-medium text-ink">All organizations</span>
               <span class="block text-[11px] text-ink-3">{{ connections().length }} configured</span>
             </span>
-            @if (selectedOrg() === null) {
+            @if (selectedKey() === null) {
               <svg class="h-3.5 w-3.5 shrink-0 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
               </svg>
@@ -82,15 +82,15 @@
           </button>
         }
 
-        @for (conn of connections(); track conn.organization) {
+        @for (conn of connections(); track conn.host + '|' + conn.organization) {
           <div class="flex items-center gap-1">
             @if (showSelection()) {
               <button
                 type="button"
-                (click)="selectOrg(conn.organization)"
+                (click)="select(conn)"
                 class="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-2 transition-colors hover:bg-ghost focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                [class.bg-accent-subtle]="isActiveOrg(conn.organization)"
-                [attr.aria-pressed]="isActiveOrg(conn.organization)"
+                [class.bg-accent-subtle]="isActive(conn)"
+                [attr.aria-pressed]="isActive(conn)"
                 [attr.aria-label]="'Show only ' + conn.organization"
               >
                 <span
@@ -99,9 +99,9 @@
                 >{{ conn.organization.charAt(0).toUpperCase() }}</span>
                 <span class="min-w-0 flex-1 text-left">
                   <span class="block truncate text-[13px] font-medium text-ink">{{ conn.organization }}</span>
-                  <span class="block font-mono text-[11px] text-ink-3 select-none" aria-hidden="true">••••••••</span>
+                  <span class="block truncate text-[11px] text-ink-3">{{ hostLabel(conn.host) }}</span>
                 </span>
-                @if (isActiveOrg(conn.organization)) {
+                @if (isActive(conn)) {
                   <svg class="h-3.5 w-3.5 shrink-0 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
                   </svg>
@@ -115,13 +115,13 @@
                 >{{ conn.organization.charAt(0).toUpperCase() }}</span>
                 <span class="min-w-0 flex-1">
                   <span class="block truncate text-[13px] font-medium text-ink">{{ conn.organization }}</span>
-                  <span class="block font-mono text-[11px] text-ink-3 select-none" aria-hidden="true">••••••••</span>
+                  <span class="block truncate text-[11px] text-ink-3">{{ hostLabel(conn.host) }}</span>
                 </span>
               </span>
             }
             <button
               type="button"
-              (click)="removeConnection(conn.organization)"
+              (click)="removeConnection(conn)"
               [attr.aria-label]="'Remove ' + conn.organization"
               class="rounded p-1 text-ink-3 transition-colors hover:bg-rose-500/10 hover:text-rose-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             >
@@ -195,6 +195,65 @@
             <p id="token-storage-note" class="mt-1.5 text-[11px] text-ink-3">
               Stored for this session only — cleared when the tab is closed.
             </p>
+          </div>
+
+          <!-- Advanced: server URL + Renovate author (GHES / self-hosted Renovate) -->
+          <div>
+            <button
+              type="button"
+              (click)="toggleAdvanced()"
+              [attr.aria-expanded]="showAdvanced()"
+              class="flex items-center gap-1 text-[11px] font-medium text-ink-3 transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
+            >
+              <svg
+                class="h-3 w-3 transition-transform duration-200"
+                [class.rotate-90]="showAdvanced()"
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+              </svg>
+              Advanced
+            </button>
+
+            @if (showAdvanced()) {
+              <div class="mt-3 space-y-3">
+                <div>
+                  <label for="draft-host" class="mb-1.5 block text-xs font-medium text-ink-2">Server URL</label>
+                  <input
+                    id="draft-host"
+                    type="text"
+                    [value]="draftHost()"
+                    (input)="onDraftHostChange($event)"
+                    placeholder="https://github.com"
+                    aria-describedby="host-note"
+                    class="w-full rounded-md border border-edge bg-ghost px-3 py-2 text-sm text-ink placeholder:text-ink-3 transition duration-200 focus:outline-none focus:ring-2 focus:ring-accent"
+                  />
+                  @if (draftHostInvalid()) {
+                    <p class="mt-1 text-xs text-amber-400">Enter a valid http(s) URL.</p>
+                  } @else {
+                    <p id="host-note" class="mt-1.5 text-[11px] text-ink-3">
+                      For GitHub Enterprise Server; leave empty for github.com.
+                    </p>
+                  }
+                </div>
+
+                <div>
+                  <label for="draft-author" class="mb-1.5 block text-xs font-medium text-ink-2">Renovate bot author</label>
+                  <input
+                    id="draft-author"
+                    type="text"
+                    [value]="draftAuthor()"
+                    (input)="onDraftAuthorChange($event)"
+                    placeholder="app/renovate"
+                    aria-describedby="author-note"
+                    class="w-full rounded-md border border-edge bg-ghost px-3 py-2 text-sm text-ink placeholder:text-ink-3 transition duration-200 focus:outline-none focus:ring-2 focus:ring-accent"
+                  />
+                  <p id="author-note" class="mt-1.5 text-[11px] text-ink-3">
+                    Search author for Renovate PRs — set this if Renovate runs self-hosted (e.g. a bot username).
+                  </p>
+                </div>
+              </div>
+            }
           </div>
 
           <button

--- a/src/app/components/org-switcher/org-switcher.component.spec.ts
+++ b/src/app/components/org-switcher/org-switcher.component.spec.ts
@@ -2,10 +2,10 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { OrgSwitcherComponent } from './org-switcher.component';
-import { OrgConnection } from '../../models/pull-request.model';
+import { connectionKey, DEFAULT_GITHUB_HOST, OrgConnection } from '../../models/pull-request.model';
 
-const ORG_A: OrgConnection = { organization: 'org-a', token: 'ghp_aaa' };
-const ORG_B: OrgConnection = { organization: 'org-b', token: 'ghp_bbb' };
+const ORG_A: OrgConnection = { platform: 'github', host: DEFAULT_GITHUB_HOST, organization: 'org-a', token: 'ghp_aaa' };
+const ORG_B: OrgConnection = { platform: 'github', host: DEFAULT_GITHUB_HOST, organization: 'org-b', token: 'ghp_bbb' };
 
 describe('OrgSwitcherComponent', () => {
   let overlayEl: HTMLElement;
@@ -54,7 +54,7 @@ describe('OrgSwitcherComponent', () => {
 
     it('shows the selected org when one is active', () => {
       const fixture = createFixture([ORG_A, ORG_B]);
-      fixture.componentRef.setInput('selectedOrg', 'org-b');
+      fixture.componentRef.setInput('selectedKey', connectionKey(ORG_B));
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toContain('org-b');
     });
@@ -73,27 +73,27 @@ describe('OrgSwitcherComponent', () => {
       expect(overlayEl.textContent).not.toContain('All organizations');
     });
 
-    it('emits selectedOrgChange with the org and closes when an org is clicked', () => {
+    it('emits selectedKeyChange with the connection key and closes when an org is clicked', () => {
       const fixture = createFixture([ORG_A, ORG_B]);
       openPopover(fixture);
 
       const emitted: (string | null)[] = [];
-      fixture.componentInstance.selectedOrgChange.subscribe((v: string | null) => emitted.push(v));
+      fixture.componentInstance.selectedKeyChange.subscribe((v: string | null) => emitted.push(v));
 
       (overlayEl.querySelector('[aria-label="Show only org-b"]') as HTMLButtonElement).click();
       fixture.detectChanges();
 
-      expect(emitted).toEqual(['org-b']);
+      expect(emitted).toEqual([connectionKey(ORG_B)]);
       expect(fixture.componentInstance.open()).toBe(false);
     });
 
     it('emits null when "All organizations" is clicked', () => {
       const fixture = createFixture([ORG_A, ORG_B]);
-      fixture.componentRef.setInput('selectedOrg', 'org-a');
+      fixture.componentRef.setInput('selectedKey', connectionKey(ORG_A));
       openPopover(fixture);
 
       const emitted: (string | null)[] = [];
-      fixture.componentInstance.selectedOrgChange.subscribe((v: string | null) => emitted.push(v));
+      fixture.componentInstance.selectedKeyChange.subscribe((v: string | null) => emitted.push(v));
 
       const allBtn = Array.from(overlayEl.querySelectorAll('button')).find(
         b => b.textContent?.includes('All organizations')) as HTMLButtonElement;
@@ -104,7 +104,7 @@ describe('OrgSwitcherComponent', () => {
 
     it('marks the active org with aria-pressed', () => {
       const fixture = createFixture([ORG_A, ORG_B]);
-      fixture.componentRef.setInput('selectedOrg', 'org-a');
+      fixture.componentRef.setInput('selectedKey', connectionKey(ORG_A));
       openPopover(fixture);
 
       expect(overlayEl.querySelector('[aria-label="Show only org-a"]')?.getAttribute('aria-pressed')).toBe('true');
@@ -217,6 +217,55 @@ describe('OrgSwitcherComponent', () => {
       expect(fixture.componentInstance.open()).toBe(false);
       expect(fixture.componentInstance.draftOrg()).toBe('');
       expect(fixture.componentInstance.draftToken()).toBe('');
+    });
+
+    it('emits a normalized host and author from the advanced fields', () => {
+      const fixture = createFixture([]);
+      openPopover(fixture);
+      fixture.componentInstance.draftOrg.set('ghes-org');
+      fixture.componentInstance.draftToken.set('ghp_ghes');
+      fixture.componentInstance.draftHost.set('https://ghes.example.com/');
+      fixture.componentInstance.draftAuthor.set(' renovate-bot ');
+      fixture.detectChanges();
+
+      const emitted: OrgConnection[][] = [];
+      fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) => emitted.push(v));
+
+      (overlayEl.querySelector('form') as HTMLFormElement).dispatchEvent(new Event('submit'));
+
+      expect(emitted[0]).toEqual([{
+        platform: 'github',
+        host: 'https://ghes.example.com',
+        organization: 'ghes-org',
+        token: 'ghp_ghes',
+        renovateAuthor: 'renovate-bot',
+      }]);
+    });
+
+    it('rejects an unparsable server URL', () => {
+      const fixture = createFixture([]);
+      openPopover(fixture);
+      fixture.componentInstance.draftOrg.set('org');
+      fixture.componentInstance.draftToken.set('tok');
+      fixture.componentInstance.draftHost.set('not a url');
+      fixture.componentInstance.showAdvanced.set(true);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.draftValid()).toBe(false);
+      expect(overlayEl.textContent).toContain('Enter a valid http(s) URL');
+    });
+
+    it('treats the same org on a different host as a new connection, not a duplicate', () => {
+      const fixture = createFixture([ORG_A]); // org-a on github.com
+      fixture.componentInstance.draftOrg.set('org-a');
+      fixture.componentInstance.draftToken.set('tok');
+
+      expect(fixture.componentInstance.isDuplicateOrg()).toBe(true);
+
+      fixture.componentInstance.draftHost.set('https://ghes.example.com');
+
+      expect(fixture.componentInstance.isDuplicateOrg()).toBe(false);
+      expect(fixture.componentInstance.draftValid()).toBe(true);
     });
 
     it('does not emit when the draft is invalid', () => {

--- a/src/app/components/org-switcher/org-switcher.component.ts
+++ b/src/app/components/org-switcher/org-switcher.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 import { OverlayModule, ConnectedPosition } from '@angular/cdk/overlay';
 import { A11yModule } from '@angular/cdk/a11y';
-import { OrgConnection } from '../../models/pull-request.model';
+import { connectionKey, DEFAULT_GITHUB_HOST, normalizeHost, OrgConnection } from '../../models/pull-request.model';
 
 /**
  * Sidebar organization switcher: a trigger button summarizing the configured
@@ -16,15 +16,18 @@ import { OrgConnection } from '../../models/pull-request.model';
 })
 export class OrgSwitcherComponent {
   connections = input<OrgConnection[]>([]);
-  /** Active org filter; null means "all organizations". */
-  selectedOrg = input<string | null>(null);
+  /** Active org filter as a canonical connection key; null means "all organizations". */
+  selectedKey = input<string | null>(null);
   connectionsChange = output<OrgConnection[]>();
-  selectedOrgChange = output<string | null>();
+  selectedKeyChange = output<string | null>();
 
   open = signal(false);
   view = signal<'list' | 'add'>('list');
+  showAdvanced = signal(false);
   draftOrg = signal('');
   draftToken = signal('');
+  draftHost = signal('');
+  draftAuthor = signal('');
 
   // Prefer opening upward (the trigger sits at the bottom of the sidebar);
   // fall back to downward if there is no room above.
@@ -33,18 +36,33 @@ export class OrgSwitcherComponent {
     { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 8 },
   ];
 
+  selectedConnection = computed(() => {
+    const key = this.selectedKey();
+    if (!key) return undefined;
+    return this.connections().find(c => connectionKey(c) === key);
+  });
+
   triggerLabel = computed(() => {
-    const selected = this.selectedOrg();
-    if (selected) return selected;
+    const selected = this.selectedConnection();
+    if (selected) return selected.organization;
     const conns = this.connections();
     if (conns.length === 0) return 'Add organization';
     if (conns.length === 1) return conns[0].organization;
     return 'All organizations';
   });
 
+  triggerSublabel = computed(() => {
+    const selected = this.selectedConnection();
+    if (selected) return this.hostLabel(selected.host);
+    const hosts = [...new Set(this.connections().map(c => c.host))];
+    if (hosts.length === 1) return this.hostLabel(hosts[0]);
+    if (hosts.length > 1) return `${hosts.length} servers`;
+    return this.hostLabel(DEFAULT_GITHUB_HOST);
+  });
+
   avatarInitial = computed(() => {
-    const selected = this.selectedOrg();
-    if (selected) return selected.charAt(0).toUpperCase();
+    const selected = this.selectedConnection();
+    if (selected) return selected.organization.charAt(0).toUpperCase();
     const conns = this.connections();
     if (conns.length === 1) return conns[0].organization.charAt(0).toUpperCase();
     return conns.length > 1 ? String(conns.length) : '+';
@@ -53,26 +71,44 @@ export class OrgSwitcherComponent {
   /** The org filter is only meaningful with more than one configured org. */
   showSelection = computed(() => this.connections().length > 1);
 
-  isActiveOrg(organization: string): boolean {
-    return this.selectedOrg()?.toLowerCase() === organization.toLowerCase();
+  /** Compact display form of a connection host, e.g. 'ghes.example.com'. */
+  hostLabel(host: string): string {
+    try {
+      return new URL(host).host;
+    } catch {
+      return host;
+    }
   }
 
-  selectOrg(organization: string | null): void {
-    this.selectedOrgChange.emit(organization);
+  isActive(conn: OrgConnection): boolean {
+    return this.selectedKey() === connectionKey(conn);
+  }
+
+  select(conn: OrgConnection | null): void {
+    this.selectedKeyChange.emit(conn ? connectionKey(conn) : null);
     this.close();
   }
 
+  private draftHostNormalized = computed(() => normalizeHost(this.draftHost()));
+
+  draftHostInvalid = computed(
+    () => this.draftHost().trim().length > 0 && this.draftHostNormalized() === null,
+  );
+
   isDuplicateOrg = computed(() => {
-    // GitHub org names are case-insensitive, so compare normalized values while
-    // preserving the user's typed casing for display.
-    const org = this.draftOrg().trim().toLowerCase();
-    return org.length > 0 && this.connections().some(c => c.organization.trim().toLowerCase() === org);
+    // Identity is platform + host + org (orgs are case-insensitive); the same
+    // org name on a different server is a distinct connection.
+    const organization = this.draftOrg().trim();
+    const host = this.draftHostNormalized();
+    if (!organization || !host) return false;
+    const key = connectionKey({ platform: 'github', host, organization });
+    return this.connections().some(c => connectionKey(c) === key);
   });
 
   draftValid = computed(() => {
     const org = this.draftOrg().trim();
     const token = this.draftToken().trim();
-    return org.length > 0 && token.length > 0 && !this.isDuplicateOrg();
+    return org.length > 0 && token.length > 0 && !this.isDuplicateOrg() && !this.draftHostInvalid();
   });
 
   toggle(): void {
@@ -101,6 +137,10 @@ export class OrgSwitcherComponent {
     this.view.set('list');
   }
 
+  toggleAdvanced(): void {
+    this.showAdvanced.set(!this.showAdvanced());
+  }
+
   onOverlayKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
       this.close();
@@ -115,12 +155,26 @@ export class OrgSwitcherComponent {
     this.draftToken.set((event.target as HTMLInputElement).value);
   }
 
+  onDraftHostChange(event: Event): void {
+    this.draftHost.set((event.target as HTMLInputElement).value);
+  }
+
+  onDraftAuthorChange(event: Event): void {
+    this.draftAuthor.set((event.target as HTMLInputElement).value);
+  }
+
   addConnection(): void {
     if (!this.draftValid()) return;
-    this.connectionsChange.emit([
-      ...this.connections(),
-      { organization: this.draftOrg().trim(), token: this.draftToken().trim() },
-    ]);
+    const host = this.draftHostNormalized() ?? DEFAULT_GITHUB_HOST;
+    const renovateAuthor = this.draftAuthor().trim();
+    const connection: OrgConnection = {
+      platform: 'github',
+      host,
+      organization: this.draftOrg().trim(),
+      token: this.draftToken().trim(),
+      ...(renovateAuthor ? { renovateAuthor } : {}),
+    };
+    this.connectionsChange.emit([...this.connections(), connection]);
     // Close so the refreshed results are immediately visible.
     this.close();
   }
@@ -130,12 +184,16 @@ export class OrgSwitcherComponent {
     this.addConnection();
   }
 
-  removeConnection(organization: string): void {
-    this.connectionsChange.emit(this.connections().filter(c => c.organization !== organization));
+  removeConnection(conn: OrgConnection): void {
+    const key = connectionKey(conn);
+    this.connectionsChange.emit(this.connections().filter(c => connectionKey(c) !== key));
   }
 
   private resetDraft(): void {
     this.draftOrg.set('');
     this.draftToken.set('');
+    this.draftHost.set('');
+    this.draftAuthor.set('');
+    this.showAdvanced.set(false);
   }
 }

--- a/src/app/components/overview-panel/overview-panel.component.spec.ts
+++ b/src/app/components/overview-panel/overview-panel.component.spec.ts
@@ -4,8 +4,12 @@ import { OverviewPanelComponent } from './overview-panel.component';
 import { PrGroup, PullRequest } from '../../models/pull-request.model';
 
 function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  const id = overrides.id ?? 1;
   return {
-    id: 1,
+    id,
+    uid: `github|https://github.com|${id}`,
+    platform: 'github',
+    host: 'https://github.com',
     number: 1,
     title: 'Update dependency foo to v2',
     html_url: 'https://github.com/org/repo/pull/1',

--- a/src/app/components/pr-group/pr-group.component.html
+++ b/src/app/components/pr-group/pr-group.component.html
@@ -80,10 +80,10 @@
   <!-- Expanded PR list -->
   @if (group().isExpanded) {
     <div class="border-t border-edge divide-y divide-edge">
-      @for (pr of group().prs; track pr.id) {
+      @for (pr of group().prs; track pr.uid) {
         <app-pr-item
           [pr]="pr"
-          [expanded]="expandedPrIds().has(pr.id)"
+          [expanded]="expandedPrIds().has(pr.uid)"
           (toggleExpanded)="togglePrExpansion(pr)"
           (closePr)="onClosePr($event)"
           (approveAndMergePr)="onApproveAndMergePr($event)">

--- a/src/app/components/pr-group/pr-group.component.spec.ts
+++ b/src/app/components/pr-group/pr-group.component.spec.ts
@@ -9,8 +9,12 @@ function findButtonByText(nativeElement: HTMLElement, text: string): HTMLButtonE
 }
 
 function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  const id = overrides.id ?? 1;
   return {
-    id: 1,
+    id,
+    uid: `github|https://github.com|${id}`,
+    platform: 'github',
+    host: 'https://github.com',
     number: 1,
     title: 'Update dependency foo to v2',
     html_url: 'https://github.com/org/repo/pull/1',

--- a/src/app/components/pr-group/pr-group.component.ts
+++ b/src/app/components/pr-group/pr-group.component.ts
@@ -11,7 +11,7 @@ import { PrItemComponent } from '../pr-item/pr-item.component';
 })
 export class PrGroupComponent {
   group = input.required<PrGroup>();
-  expandedPrIds = input<ReadonlySet<number>>(new Set<number>());
+  expandedPrIds = input<ReadonlySet<string>>(new Set<string>());
 
   toggleGroup = output<PrGroup>();
   closePr = output<PullRequest>();

--- a/src/app/components/pr-item/pr-item.component.spec.ts
+++ b/src/app/components/pr-item/pr-item.component.spec.ts
@@ -9,8 +9,12 @@ function findButtonByText(nativeElement: HTMLElement, text: string): HTMLButtonE
 }
 
 function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  const id = overrides.id ?? 1;
   return {
-    id: 1,
+    id,
+    uid: `github|https://github.com|${id}`,
+    platform: 'github',
+    host: 'https://github.com',
     number: 42,
     title: 'Update dependency foo to v2',
     html_url: 'https://github.com/org/repo/pull/42',

--- a/src/app/models/pull-request.model.ts
+++ b/src/app/models/pull-request.model.ts
@@ -1,8 +1,51 @@
 export type CiStatus = 'success' | 'failure' | 'pending' | 'unknown';
 
+export type Platform = 'github' | 'gitlab';
+
+export const DEFAULT_GITHUB_HOST = 'https://github.com';
+
 export interface OrgConnection {
+  platform: Platform;
+  /** Origin URL of the instance, e.g. 'https://github.com' or 'https://ghes.example.com'. */
+  host: string;
   organization: string;
   token: string;
+  /** Search author for Renovate PRs; provider default (e.g. 'app/renovate') when unset. */
+  renovateAuthor?: string;
+}
+
+/**
+ * Normalize a user-supplied host to an http(s) origin. An empty value means
+ * "the default GitHub host"; an unparsable or non-http(s) value returns null.
+ */
+export function normalizeHost(raw: string): string | null {
+  const trimmed = raw.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return DEFAULT_GITHUB_HOST;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Canonical identity of a connection: the same org name can exist on
+ * different hosts/platforms, so identity is the triple, org compared
+ * case-insensitively.
+ */
+export function connectionKey(c: Pick<OrgConnection, 'platform' | 'host' | 'organization'>): string {
+  return `${c.platform}|${c.host}|${c.organization.toLowerCase()}`;
+}
+
+/** The connection key of the connection a PR was fetched through. */
+export function prConnectionKey(pr: Pick<PullRequest, 'platform' | 'host' | 'repoOwner'>): string {
+  return `${pr.platform}|${pr.host}|${pr.repoOwner.toLowerCase()}`;
 }
 
 export interface GitHubUser {
@@ -67,6 +110,15 @@ export interface GitHubCombinedStatusResponse {
 
 export interface PullRequest {
   id: number;
+  /**
+   * Globally unique key for UI tracking (expansion state, removal). Numeric
+   * ids are only unique within one instance, so providers derive this from
+   * platform + host + id.
+   */
+  uid: string;
+  /** Platform and host of the connection this PR was fetched through. */
+  platform: Platform;
+  host: string;
   number: number;
   title: string;
   html_url: string;

--- a/src/app/services/github-provider.service.spec.ts
+++ b/src/app/services/github-provider.service.spec.ts
@@ -4,7 +4,12 @@ import { vi } from 'vitest';
 import { GitHubProviderService } from './github-provider.service';
 import { OrgConnection, PullRequest } from '../models/pull-request.model';
 
-const CONNECTION: OrgConnection = { organization: 'my-org', token: 'ghp_test' };
+const CONNECTION: OrgConnection = {
+  platform: 'github',
+  host: 'https://github.com',
+  organization: 'my-org',
+  token: 'ghp_test',
+};
 
 interface ProviderPrivate {
   determineMergeMethod(pr: PullRequest): string;
@@ -36,8 +41,12 @@ function jsonResponse(body: unknown) {
 }
 
 function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  const id = overrides.id ?? 1;
   return {
-    id: 1,
+    id,
+    uid: `github|https://github.com|${id}`,
+    platform: 'github',
+    host: 'https://github.com',
     number: 1,
     title: 'Update dependency foo to v2',
     html_url: 'https://github.com/my-org/repo/pull/1',
@@ -87,6 +96,9 @@ describe('GitHubProviderService', () => {
       expect(prs).toHaveLength(1);
       expect(prs[0]).toMatchObject({
         id: 7,
+        uid: 'github|https://github.com|7',
+        platform: 'github',
+        host: 'https://github.com',
         number: 7,
         repoOwner: 'my-org',
         repoName: 'my-repo',
@@ -95,6 +107,16 @@ describe('GitHubProviderService', () => {
         workflowStatus: 'unknown',
         isProcessing: false,
       });
+    });
+
+    it('uses a per-connection Renovate author when configured', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(searchResponse([]));
+
+      await provider.searchRenovatePrs({ ...CONNECTION, renovateAuthor: 'renovate-bot' });
+
+      const calledUrl = String(fetchSpy.mock.calls[0][0]);
+      expect(calledUrl).toContain('author%3Arenovate-bot');
+      expect(calledUrl).not.toContain('app%2Frenovate');
     });
 
     it('fetches all items across multiple pages', async () => {
@@ -274,6 +296,40 @@ describe('GitHubProviderService', () => {
       expect(String(url)).toContain('/pulls/9');
       expect((init as RequestInit).method).toBe('PATCH');
       expect((init as RequestInit).body).toContain('closed');
+    });
+  });
+
+  describe('GitHub Enterprise Server hosts', () => {
+    const GHES: OrgConnection = { ...CONNECTION, host: 'https://ghes.example.com' };
+
+    it('searches under <host>/api/v3', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(searchResponse([]));
+
+      await provider.searchRenovatePrs(GHES);
+
+      expect(String(fetchSpy.mock.calls[0][0])).toContain('https://ghes.example.com/api/v3/search/issues');
+    });
+
+    it('derives PR uid and host from the connection', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(searchResponse([makeItem(3)]));
+
+      const { prs } = await provider.searchRenovatePrs(GHES);
+
+      expect(prs[0].host).toBe('https://ghes.example.com');
+      expect(prs[0].uid).toBe('github|https://ghes.example.com|3');
+    });
+
+    it('issues detail and action requests against the PR host', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+      const pr = makePr({ host: 'https://ghes.example.com', number: 4, allowMergeCommit: true });
+
+      await provider.close(pr);
+      await provider.approveAndMerge(pr);
+
+      const urls = fetchSpy.mock.calls.map(args => String(args[0]));
+      expect(urls[0]).toBe('https://ghes.example.com/api/v3/repos/my-org/repo/pulls/4');
+      expect(urls[1]).toContain('https://ghes.example.com/api/v3/repos/my-org/repo/pulls/4/reviews');
+      expect(urls.every(u => !u.includes('api.github.com'))).toBe(true);
     });
   });
 

--- a/src/app/services/github-provider.service.ts
+++ b/src/app/services/github-provider.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import {
   CiStatus,
+  DEFAULT_GITHUB_HOST,
   GitHubCheckRunsResponse,
   GitHubCombinedStatusResponse,
   GitHubIssueSearchItem,
@@ -12,12 +13,24 @@ import {
 } from '../models/pull-request.model';
 import { GitProvider, ProviderSearchResult } from './git-provider';
 
-/** GitProvider implementation for github.com via the REST v3 API. */
+const DEFAULT_RENOVATE_AUTHOR = 'app/renovate';
+
+/**
+ * REST API root for a GitHub host: github.com uses the dedicated api
+ * subdomain; GitHub Enterprise Server serves the identical API under
+ * /api/v3 on the instance host.
+ */
+export function githubApiBase(host: string): string {
+  return host === DEFAULT_GITHUB_HOST ? 'https://api.github.com' : `${host}/api/v3`;
+}
+
+/** GitProvider implementation for github.com and GitHub Enterprise Server (REST v3 API). */
 @Injectable({ providedIn: 'root' })
 export class GitHubProviderService implements GitProvider {
   async searchRenovatePrs(connection: OrgConnection): Promise<ProviderSearchResult> {
-    const query = `is:pr author:app/renovate org:${connection.organization} is:open`;
-    const { items, incompleteResults } = await this.fetchAllSearchItems(query, connection.token);
+    const author = connection.renovateAuthor?.trim() || DEFAULT_RENOVATE_AUTHOR;
+    const query = `is:pr author:${author} org:${connection.organization} is:open`;
+    const { items, incompleteResults } = await this.fetchAllSearchItems(connection.host, query, connection.token);
 
     const prs: PullRequest[] = [];
     for (const item of items) {
@@ -30,6 +43,9 @@ export class GitHubProviderService implements GitProvider {
 
       prs.push({
         id: item.id,
+        uid: `${connection.platform}|${connection.host}|${item.id}`,
+        platform: connection.platform,
+        host: connection.host,
         number: item.number,
         title: item.title,
         html_url: item.html_url,
@@ -54,28 +70,29 @@ export class GitHubProviderService implements GitProvider {
   }
 
   async fetchPrDetails(pr: PullRequest): Promise<void> {
+    const apiBase = githubApiBase(pr.host);
     try {
       // Get full PR data (for commit count and head SHA)
-      const prUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}`;
+      const prUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}`;
       const prData = await this.apiRequest<GitHubPullRequestDetails>(prUrl, pr.orgToken);
       pr.isModified = prData.commits > 1;
       pr.head.sha = prData.head.sha;
       pr.commits = prData.commits;
 
       // Get repository settings to determine allowed merge methods
-      const repoUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}`;
+      const repoUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}`;
       const repoData = await this.apiRequest<GitHubRepository>(repoUrl, pr.orgToken);
       pr.allowSquashMerge = repoData.allow_squash_merge;
       pr.allowMergeCommit = repoData.allow_merge_commit;
       pr.allowRebaseMerge = repoData.allow_rebase_merge;
 
       // Get combined CI status for the PR's head commit (as a fallback)
-      const statusUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/status`;
+      const statusUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/status`;
       const statusData = await this.apiRequest<GitHubCombinedStatusResponse>(statusUrl, pr.orgToken);
       pr.ciStatus = this.mapCombinedStatus(statusData.state);
 
       // Get individual check runs for more detailed status
-      const checksUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/check-runs`;
+      const checksUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/check-runs`;
       const checksData = await this.apiRequest<GitHubCheckRunsResponse>(checksUrl, pr.orgToken);
       if (checksData && checksData.check_runs) {
         pr.checkRuns = checksData.check_runs.map(cr => ({
@@ -115,24 +132,25 @@ export class GitHubProviderService implements GitProvider {
   }
 
   async approveAndMerge(pr: PullRequest): Promise<void> {
+    const apiBase = githubApiBase(pr.host);
     // Step 1: Approve
-    const reviewUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}/reviews`;
+    const reviewUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}/reviews`;
     await this.apiRequest<void>(reviewUrl, pr.orgToken, 'POST', { event: 'APPROVE' });
 
     // Step 2: Merge with a method appropriate for the PR and repo settings
     const mergeMethod = this.determineMergeMethod(pr);
-    const mergeUrl = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}/merge`;
+    const mergeUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}/merge`;
     await this.apiRequest<void>(mergeUrl, pr.orgToken, 'PUT', { merge_method: mergeMethod });
   }
 
   async close(pr: PullRequest): Promise<void> {
-    const url = `https://api.github.com/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}`;
+    const url = `${githubApiBase(pr.host)}/repos/${pr.repoOwner}/${pr.repoName}/pulls/${pr.number}`;
     await this.apiRequest<void>(url, pr.orgToken, 'PATCH', { state: 'closed' });
   }
 
   // --- INTERNALS ---
 
-  private async fetchAllSearchItems(query: string, token: string): Promise<{ items: GitHubIssueSearchItem[]; incompleteResults: boolean }> {
+  private async fetchAllSearchItems(host: string, query: string, token: string): Promise<{ items: GitHubIssueSearchItem[]; incompleteResults: boolean }> {
     const headers = {
       'Accept': 'application/vnd.github.v3+json',
       'Authorization': `token ${token}`
@@ -142,7 +160,7 @@ export class GitHubProviderService implements GitProvider {
 
     for (let page = 1; page <= 10; page++) {
       const params = new URLSearchParams({ q: query, per_page: '100', page: String(page) });
-      const url = `https://api.github.com/search/issues?${params.toString()}`;
+      const url = `${githubApiBase(host)}/search/issues?${params.toString()}`;
       const response = await fetch(url, { headers });
       if (!response.ok) {
         let errorMessage = response.statusText


### PR DESCRIPTION
Phase 2 of multi-platform support (#81): **GitHub Enterprise Server works end to end**, via the connection model v2.

## Connection model v2

`OrgConnection` gains `platform` (`'github' | 'gitlab'`), `host` (an http(s) origin, default `https://github.com`), and optional `renovateAuthor`:

- **Transparent migration**: `sanitizeConnections` defaults/normalizes the new fields, so connections stored before this change (and the even older single-org keys) keep working. Hosts are normalized to origins (trailing slashes stripped); entries with unparsable hosts are dropped.
- **Host-qualified identity**: connection identity is now a canonical key (`platform|host|org-lowercased`). Dedupe, the per-org filter, and the switcher selection all use it, so `my-org` on github.com and `my-org` on a GHES instance are distinct connections that can coexist. The persisted selection stores the key; bare org names from older sessions are still recognized and upgraded.
- **Globally unique PR tracking**: `PullRequest` gains `platform`, `host`, and a `uid` (`platform|host|id`). Expansion state and PR removal key on `uid`, since numeric ids are only unique within one instance.

## GHES

`GitHubProviderService` routes every request through `githubApiBase()`: `api.github.com` for github.com, `<host>/api/v3` for GHES (the API is otherwise identical — search, auth scheme, CORS). The Renovate search author is now **per-connection** (default `app/renovate`) — this also fixes self-hosted Renovate on plain github.com, where the author is a bot user rather than the GitHub App.

## UI

The add-organization form gains an **Advanced** disclosure with "Server URL" (validated + normalized, empty = github.com) and "Renovate bot author" fields — the common github.com path is unchanged. Connection rows and the switcher trigger now show host sublabels (e.g. `ghes.example.com`, or "2 servers" when hosts are mixed), replacing the masked-token dots.

## Tests

178 total (+7 net): old-shape stored-connection migration, host normalization/rejection, same-org-different-host coexistence and filtering, key-based selection persistence (including legacy bare-name upgrade), GHES URL routing for search/details/actions, per-connection author query, advanced-form emission/validation, and duplicate detection being host-qualified. `npm run lint`, `npm test`, and `npm run build` all pass.

Verified in the browser: Advanced form renders and validates, a GHES org and a same-named github.com org coexist with host sublabels, trigger shows "2 servers", and requests target the configured host.

Refs #81 — phase 3 (GitLab provider) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
