### PR TITLE
GitLab provider: track Renovate MRs on gitlab.com and self-hosted GitLab

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -143,7 +143,7 @@
               <circle cx="6" cy="6" r="3"/>
               <path stroke-linecap="round" d="M13 6h3a2 2 0 0 1 2 2v7M6 9v12"/>
             </svg>
-            <p class="text-sm font-medium text-ink-2">Connect a GitHub organization</p>
+            <p class="text-sm font-medium text-ink-2">Connect an organization</p>
             <p class="mt-1 text-[13px] text-ink-3">
               Use <span class="font-medium text-ink-2">“Add organization”</span> in the sidebar to start tracking Renovate PRs.
             </p>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -6,6 +6,7 @@ import { getSourceRepositoryUrl } from './config/source-repository-url';
 import { PullRequest, PrGroup, OrgConnection, DEFAULT_GITHUB_HOST, connectionKey } from './models/pull-request.model';
 import { SessionStorageService } from './services/session-storage.service';
 import { GitHubProviderService } from './services/github-provider.service';
+import { GitLabProviderService } from './services/gitlab-provider.service';
 
 function conn(organization: string, token: string): OrgConnection {
   return { platform: 'github', host: DEFAULT_GITHUB_HOST, organization, token };
@@ -364,6 +365,45 @@ describe('App', () => {
     });
   });
 
+  describe('provider dispatch', () => {
+    function gitlabConn(organization: string, token: string): OrgConnection {
+      return { platform: 'gitlab', host: 'https://gitlab.com', organization, token };
+    }
+
+    it('routes each connection to its platform provider when searching', async () => {
+      const github = { searchRenovatePrs: vi.fn().mockResolvedValue({ prs: [], incompleteResults: false }) };
+      const gitlab = { searchRenovatePrs: vi.fn().mockResolvedValue({ prs: [], incompleteResults: false }) };
+      TestBed.overrideProvider(GitHubProviderService, { useValue: github });
+      TestBed.overrideProvider(GitLabProviderService, { useValue: gitlab });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      app.connections.set([conn('gh-org', 't1'), gitlabConn('gl-group', 't2')]);
+
+      await app.searchAndProcessPullRequests();
+
+      expect(github.searchRenovatePrs).toHaveBeenCalledTimes(1);
+      expect(github.searchRenovatePrs).toHaveBeenCalledWith(conn('gh-org', 't1'));
+      expect(gitlab.searchRenovatePrs).toHaveBeenCalledTimes(1);
+      expect(gitlab.searchRenovatePrs).toHaveBeenCalledWith(gitlabConn('gl-group', 't2'));
+    });
+
+    it('routes PR actions by the PR platform', async () => {
+      const github = { close: vi.fn().mockResolvedValue(undefined) };
+      const gitlab = { close: vi.fn().mockResolvedValue(undefined) };
+      TestBed.overrideProvider(GitHubProviderService, { useValue: github });
+      TestBed.overrideProvider(GitLabProviderService, { useValue: gitlab });
+
+      const app = TestBed.createComponent(App).componentInstance;
+      const gitlabPr = makePr({ id: 2, platform: 'gitlab', host: 'https://gitlab.com', uid: 'gitlab|https://gitlab.com|2' });
+      app.prGroups.set([makeGroup({ prs: [gitlabPr] })]);
+
+      await app.closePullRequest(gitlabPr);
+
+      expect(gitlab.close).toHaveBeenCalledWith(gitlabPr);
+      expect(github.close).not.toHaveBeenCalled();
+    });
+  });
+
   describe('searchAndProcessPullRequests — multi-org partial failure', () => {
     it('flags incomplete (not error) when one org fails but another succeeds', async () => {
       const provider = {
@@ -512,7 +552,7 @@ describe('App', () => {
       fixture.componentInstance.connections.set([]);
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toContain('Add organization');
-      expect(fixture.nativeElement.textContent).toContain('Connect a GitHub organization');
+      expect(fixture.nativeElement.textContent).toContain('Connect an organization');
     });
 
     it('renders the theme toggle button with an accessible label', () => {
@@ -540,7 +580,7 @@ describe('App', () => {
         conn('org-a', 'a'),
         conn('org-b', 'b'),
       ]);
-      expect(app.subtitle()).toContain('2 GitHub organizations');
+      expect(app.subtitle()).toContain('2 organizations');
     });
   });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -7,9 +7,11 @@ import {
   PullRequest,
   CiStatus,
   connectionKey,
+  defaultHostFor,
   normalizeHost,
   prConnectionKey,
   DEFAULT_GITHUB_HOST,
+  Platform,
 } from './models/pull-request.model';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
 import { OrgSwitcherComponent } from './components/org-switcher/org-switcher.component';
@@ -18,7 +20,9 @@ import { OverviewPanelComponent } from './components/overview-panel/overview-pan
 import { FilterBarComponent, GroupSort, StatusFilter } from './components/filter-bar/filter-bar.component';
 import { getSourceRepositoryUrl } from './config/source-repository-url';
 import { SessionStorageService, SESSION_KEYS } from './services/session-storage.service';
+import { GitProvider } from './services/git-provider';
 import { GitHubProviderService } from './services/github-provider.service';
+import { GitLabProviderService } from './services/gitlab-provider.service';
 
 @Component({
   selector: 'app-root',
@@ -29,11 +33,15 @@ import { GitHubProviderService } from './services/github-provider.service';
 export class App {
   readonly sourceRepositoryUrl = getSourceRepositoryUrl();
   private storage = inject(SessionStorageService);
-  // All platform API access goes through the provider (GitProvider); app.ts
-  // only orchestrates. GitLab/GHES support (#81) will select the provider
-  // per connection here.
-  private provider = inject(GitHubProviderService);
+  // All platform API access goes through a GitProvider; app.ts only
+  // orchestrates. The provider is chosen per connection/PR by platform.
+  private githubProvider = inject(GitHubProviderService);
+  private gitlabProvider = inject(GitLabProviderService);
   private doc = inject(DOCUMENT);
+
+  private providerFor(subject: { platform: Platform }): GitProvider {
+    return subject.platform === 'gitlab' ? this.gitlabProvider : this.githubProvider;
+  }
 
   // --- STATE SIGNALS ---
   connections = signal<OrgConnection[]>(this.loadConnections());
@@ -87,9 +95,9 @@ export class App {
       return `Monitor and manage Renovate pull requests across the ${conns[0].organization} organization`;
     }
     if (conns.length > 1) {
-      return `Monitor and manage Renovate pull requests across ${conns.length} GitHub organizations`;
+      return `Monitor and manage Renovate pull requests across ${conns.length} organizations`;
     }
-    return 'Monitor and manage Renovate pull requests across your GitHub organizations';
+    return 'Monitor and manage Renovate pull requests across your organizations';
   });
 
   /** Connections narrowed to the active org filter (all of them when unfiltered). */
@@ -270,8 +278,8 @@ export class App {
         continue;
       }
 
-      const platform = c.platform === 'gitlab' ? 'gitlab' : 'github';
-      const host = normalizeHost(typeof c.host === 'string' ? c.host : '');
+      const platform: Platform = c.platform === 'gitlab' ? 'gitlab' : 'github';
+      const host = normalizeHost(typeof c.host === 'string' ? c.host : '', defaultHostFor(platform));
       if (!host) {
         continue;
       }
@@ -338,7 +346,7 @@ export class App {
       // discard the others' results — merge what succeeded and flag the rest
       // as incomplete.
       const searchResults = await Promise.allSettled(
-        connections.map(conn => this.provider.searchRenovatePrs(conn))
+        connections.map(conn => this.providerFor(conn).searchRenovatePrs(conn))
       );
 
       if (generation !== this.searchGeneration) return; // superseded by a newer search
@@ -383,7 +391,7 @@ export class App {
       const BATCH_SIZE = 10;
       for (let i = 0; i < allPrs.length; i += BATCH_SIZE) {
         if (generation !== this.searchGeneration) return; // stop fetching for a superseded search
-        await Promise.all(allPrs.slice(i, i + BATCH_SIZE).map(pr => this.provider.fetchPrDetails(pr)));
+        await Promise.all(allPrs.slice(i, i + BATCH_SIZE).map(pr => this.providerFor(pr).fetchPrDetails(pr)));
       }
 
       if (generation !== this.searchGeneration) return;
@@ -411,7 +419,7 @@ export class App {
   async closePullRequest(prToUpdate: PullRequest) {
     this.setPrProcessingState(prToUpdate, true);
     try {
-      await this.provider.close(prToUpdate);
+      await this.providerFor(prToUpdate).close(prToUpdate);
       // Remove PR from UI
       this.removePrFromGroup(prToUpdate);
     } catch (error: unknown) {
@@ -429,7 +437,7 @@ export class App {
         throw new Error('Cannot merge PR with failing workflow checks');
       }
 
-      await this.provider.approveAndMerge(prToUpdate);
+      await this.providerFor(prToUpdate).approveAndMerge(prToUpdate);
 
       // Remove PR from UI
       this.removePrFromGroup(prToUpdate);

--- a/src/app/components/org-switcher/org-switcher.component.html
+++ b/src/app/components/org-switcher/org-switcher.component.html
@@ -15,9 +15,25 @@
   >{{ avatarInitial() }}</span>
   <span class="min-w-0 flex-1 text-left">
     <span class="flex items-center gap-1.5">
-      <svg class="h-3 w-3 shrink-0 text-ink-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/>
-      </svg>
+      @switch (triggerPlatform()) {
+        @case ('gitlab') {
+          <svg class="h-3 w-3 shrink-0 text-ink-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.49h8.1l2.44-7.51a.42.42 0 0 1 .11-.18.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.51 1.22 3.78a.84.84 0 0 1-.3.94z"/>
+          </svg>
+        }
+        @case ('github') {
+          <svg class="h-3 w-3 shrink-0 text-ink-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/>
+          </svg>
+        }
+        @default {
+          <!-- Mixed platforms: neutral globe -->
+          <svg class="h-3 w-3 shrink-0 text-ink-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+          </svg>
+        }
+      }
       <span class="truncate text-[13px] font-medium text-ink">{{ triggerLabel() }}</span>
     </span>
     <span class="block truncate text-[11px] text-ink-3">{{ triggerSublabel() }}</span>
@@ -167,13 +183,45 @@
 
         <div class="space-y-3 p-3">
           <div>
-            <label for="draft-org" class="mb-1.5 block text-xs font-medium text-ink-2">Organization</label>
+            <span class="mb-1.5 block text-xs font-medium text-ink-2">Platform</span>
+            <div class="flex gap-2" role="group" aria-label="Platform">
+              @for (p of platforms; track p.value) {
+                <button
+                  type="button"
+                  (click)="setDraftPlatform(p.value)"
+                  [attr.aria-pressed]="draftPlatform() === p.value"
+                  class="flex flex-1 items-center justify-center gap-1.5 rounded-md border py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  [class.border-accent]="draftPlatform() === p.value"
+                  [class.bg-accent-subtle]="draftPlatform() === p.value"
+                  [class.text-accent]="draftPlatform() === p.value"
+                  [class.border-edge]="draftPlatform() !== p.value"
+                  [class.text-ink-3]="draftPlatform() !== p.value"
+                  [class.hover:bg-ghost]="draftPlatform() !== p.value"
+                  [class.hover:text-ink]="draftPlatform() !== p.value"
+                >
+                  @if (p.value === 'gitlab') {
+                    <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.49h8.1l2.44-7.51a.42.42 0 0 1 .11-.18.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.51 1.22 3.78a.84.84 0 0 1-.3.94z"/>
+                    </svg>
+                  } @else {
+                    <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z"/>
+                    </svg>
+                  }
+                  {{ p.label }}
+                </button>
+              }
+            </div>
+          </div>
+
+          <div>
+            <label for="draft-org" class="mb-1.5 block text-xs font-medium text-ink-2">{{ draftCopy().orgLabel }}</label>
             <input
               id="draft-org"
               type="text"
               [value]="draftOrg()"
               (input)="onDraftOrgChange($event)"
-              placeholder="e.g., my-github-org"
+              [placeholder]="draftCopy().orgPlaceholder"
               class="w-full rounded-md border border-edge bg-ghost px-3 py-2 text-sm text-ink placeholder:text-ink-3 transition duration-200 focus:outline-none focus:ring-2 focus:ring-accent"
             />
             @if (isDuplicateOrg()) {
@@ -188,7 +236,7 @@
               type="password"
               [value]="draftToken()"
               (input)="onDraftTokenChange($event)"
-              placeholder="Token with 'repo' scope"
+              [placeholder]="draftCopy().tokenPlaceholder"
               aria-describedby="token-storage-note"
               class="w-full rounded-md border border-edge bg-ghost px-3 py-2 text-sm text-ink placeholder:text-ink-3 transition duration-200 focus:outline-none focus:ring-2 focus:ring-accent"
             />
@@ -224,7 +272,7 @@
                     type="text"
                     [value]="draftHost()"
                     (input)="onDraftHostChange($event)"
-                    placeholder="https://github.com"
+                    [placeholder]="draftCopy().hostPlaceholder"
                     aria-describedby="host-note"
                     class="w-full rounded-md border border-edge bg-ghost px-3 py-2 text-sm text-ink placeholder:text-ink-3 transition duration-200 focus:outline-none focus:ring-2 focus:ring-accent"
                   />
@@ -232,7 +280,7 @@
                     <p class="mt-1 text-xs text-amber-400">Enter a valid http(s) URL.</p>
                   } @else {
                     <p id="host-note" class="mt-1.5 text-[11px] text-ink-3">
-                      For GitHub Enterprise Server; leave empty for github.com.
+                      {{ draftCopy().hostNote }}
                     </p>
                   }
                 </div>
@@ -244,7 +292,7 @@
                     type="text"
                     [value]="draftAuthor()"
                     (input)="onDraftAuthorChange($event)"
-                    placeholder="app/renovate"
+                    [placeholder]="draftCopy().authorPlaceholder"
                     aria-describedby="author-note"
                     class="w-full rounded-md border border-edge bg-ghost px-3 py-2 text-sm text-ink placeholder:text-ink-3 transition duration-200 focus:outline-none focus:ring-2 focus:ring-accent"
                   />

--- a/src/app/components/org-switcher/org-switcher.component.spec.ts
+++ b/src/app/components/org-switcher/org-switcher.component.spec.ts
@@ -268,6 +268,55 @@ describe('OrgSwitcherComponent', () => {
       expect(fixture.componentInstance.draftValid()).toBe(true);
     });
 
+    it('emits a GitLab connection with the gitlab.com default host when GitLab is selected', () => {
+      const fixture = createFixture([]);
+      openPopover(fixture);
+      fixture.componentInstance.setDraftPlatform('gitlab');
+      fixture.componentInstance.draftOrg.set('my-group');
+      fixture.componentInstance.draftToken.set('glpat-x');
+      fixture.detectChanges();
+
+      const emitted: OrgConnection[][] = [];
+      fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) => emitted.push(v));
+
+      (overlayEl.querySelector('form') as HTMLFormElement).dispatchEvent(new Event('submit'));
+
+      expect(emitted[0]).toEqual([{
+        platform: 'gitlab',
+        host: 'https://gitlab.com',
+        organization: 'my-group',
+        token: 'glpat-x',
+      }]);
+    });
+
+    it('adapts the add-form copy to the selected platform', () => {
+      const fixture = createFixture([]);
+      openPopover(fixture);
+      expect(overlayEl.textContent).toContain('Organization');
+
+      fixture.componentInstance.setDraftPlatform('gitlab');
+      fixture.detectChanges();
+
+      expect(overlayEl.textContent).toContain('Group');
+      const tokenInput = overlayEl.querySelector('#draft-token') as HTMLInputElement;
+      expect(tokenInput.placeholder).toContain("'api' scope");
+    });
+
+    it('treats the same org on a different platform as a new connection', () => {
+      const gitlabOrgA: OrgConnection = {
+        platform: 'gitlab', host: 'https://gitlab.com', organization: 'org-a', token: 't',
+      };
+      const fixture = createFixture([gitlabOrgA]);
+      fixture.componentInstance.draftOrg.set('org-a');
+      fixture.componentInstance.draftToken.set('tok');
+
+      // Draft defaults to GitHub on github.com — distinct from the GitLab connection.
+      expect(fixture.componentInstance.isDuplicateOrg()).toBe(false);
+
+      fixture.componentInstance.setDraftPlatform('gitlab');
+      expect(fixture.componentInstance.isDuplicateOrg()).toBe(true);
+    });
+
     it('does not emit when the draft is invalid', () => {
       const fixture = createFixture([]);
       const emitted: OrgConnection[][] = [];

--- a/src/app/components/org-switcher/org-switcher.component.ts
+++ b/src/app/components/org-switcher/org-switcher.component.ts
@@ -1,7 +1,14 @@
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 import { OverlayModule, ConnectedPosition } from '@angular/cdk/overlay';
 import { A11yModule } from '@angular/cdk/a11y';
-import { connectionKey, DEFAULT_GITHUB_HOST, normalizeHost, OrgConnection } from '../../models/pull-request.model';
+import {
+  connectionKey,
+  defaultHostFor,
+  normalizeHost,
+  OrgConnection,
+  Platform,
+  DEFAULT_GITHUB_HOST,
+} from '../../models/pull-request.model';
 
 /**
  * Sidebar organization switcher: a trigger button summarizing the configured
@@ -24,10 +31,38 @@ export class OrgSwitcherComponent {
   open = signal(false);
   view = signal<'list' | 'add'>('list');
   showAdvanced = signal(false);
+  draftPlatform = signal<Platform>('github');
   draftOrg = signal('');
   draftToken = signal('');
   draftHost = signal('');
   draftAuthor = signal('');
+
+  readonly platforms: { value: Platform; label: string }[] = [
+    { value: 'github', label: 'GitHub' },
+    { value: 'gitlab', label: 'GitLab' },
+  ];
+
+  /** Platform-dependent add-form copy. */
+  draftCopy = computed(() => {
+    if (this.draftPlatform() === 'gitlab') {
+      return {
+        orgLabel: 'Group',
+        orgPlaceholder: 'e.g., my-group',
+        tokenPlaceholder: "Token with 'api' scope",
+        hostPlaceholder: 'https://gitlab.com',
+        hostNote: 'For self-hosted GitLab; leave empty for gitlab.com.',
+        authorPlaceholder: 'renovate-bot',
+      };
+    }
+    return {
+      orgLabel: 'Organization',
+      orgPlaceholder: 'e.g., my-github-org',
+      tokenPlaceholder: "Token with 'repo' scope",
+      hostPlaceholder: 'https://github.com',
+      hostNote: 'For GitHub Enterprise Server; leave empty for github.com.',
+      authorPlaceholder: 'app/renovate',
+    };
+  });
 
   // Prefer opening upward (the trigger sits at the bottom of the sidebar);
   // fall back to downward if there is no room above.
@@ -68,6 +103,15 @@ export class OrgSwitcherComponent {
     return conns.length > 1 ? String(conns.length) : '+';
   });
 
+  /** Platform mark shown in the trigger; null when connections span both platforms. */
+  triggerPlatform = computed<Platform | null>(() => {
+    const selected = this.selectedConnection();
+    if (selected) return selected.platform;
+    const platforms = [...new Set(this.connections().map(c => c.platform))];
+    if (platforms.length === 1) return platforms[0];
+    return platforms.length === 0 ? 'github' : null;
+  });
+
   /** The org filter is only meaningful with more than one configured org. */
   showSelection = computed(() => this.connections().length > 1);
 
@@ -89,7 +133,9 @@ export class OrgSwitcherComponent {
     this.close();
   }
 
-  private draftHostNormalized = computed(() => normalizeHost(this.draftHost()));
+  private draftHostNormalized = computed(() =>
+    normalizeHost(this.draftHost(), defaultHostFor(this.draftPlatform())),
+  );
 
   draftHostInvalid = computed(
     () => this.draftHost().trim().length > 0 && this.draftHostNormalized() === null,
@@ -97,13 +143,17 @@ export class OrgSwitcherComponent {
 
   isDuplicateOrg = computed(() => {
     // Identity is platform + host + org (orgs are case-insensitive); the same
-    // org name on a different server is a distinct connection.
+    // org name on a different server or platform is a distinct connection.
     const organization = this.draftOrg().trim();
     const host = this.draftHostNormalized();
     if (!organization || !host) return false;
-    const key = connectionKey({ platform: 'github', host, organization });
+    const key = connectionKey({ platform: this.draftPlatform(), host, organization });
     return this.connections().some(c => connectionKey(c) === key);
   });
+
+  setDraftPlatform(platform: Platform): void {
+    this.draftPlatform.set(platform);
+  }
 
   draftValid = computed(() => {
     const org = this.draftOrg().trim();
@@ -165,10 +215,10 @@ export class OrgSwitcherComponent {
 
   addConnection(): void {
     if (!this.draftValid()) return;
-    const host = this.draftHostNormalized() ?? DEFAULT_GITHUB_HOST;
+    const host = this.draftHostNormalized() ?? defaultHostFor(this.draftPlatform());
     const renovateAuthor = this.draftAuthor().trim();
     const connection: OrgConnection = {
-      platform: 'github',
+      platform: this.draftPlatform(),
       host,
       organization: this.draftOrg().trim(),
       token: this.draftToken().trim(),
@@ -190,6 +240,7 @@ export class OrgSwitcherComponent {
   }
 
   private resetDraft(): void {
+    this.draftPlatform.set('github');
     this.draftOrg.set('');
     this.draftToken.set('');
     this.draftHost.set('');

--- a/src/app/models/pull-request.model.ts
+++ b/src/app/models/pull-request.model.ts
@@ -3,6 +3,11 @@ export type CiStatus = 'success' | 'failure' | 'pending' | 'unknown';
 export type Platform = 'github' | 'gitlab';
 
 export const DEFAULT_GITHUB_HOST = 'https://github.com';
+export const DEFAULT_GITLAB_HOST = 'https://gitlab.com';
+
+export function defaultHostFor(platform: Platform): string {
+  return platform === 'gitlab' ? DEFAULT_GITLAB_HOST : DEFAULT_GITHUB_HOST;
+}
 
 export interface OrgConnection {
   platform: Platform;
@@ -16,12 +21,12 @@ export interface OrgConnection {
 
 /**
  * Normalize a user-supplied host to an http(s) origin. An empty value means
- * "the default GitHub host"; an unparsable or non-http(s) value returns null.
+ * "the platform's default host"; an unparsable or non-http(s) value returns null.
  */
-export function normalizeHost(raw: string): string | null {
+export function normalizeHost(raw: string, defaultHost: string = DEFAULT_GITHUB_HOST): string | null {
   const trimmed = raw.trim().replace(/\/+$/, '');
   if (!trimmed) {
-    return DEFAULT_GITHUB_HOST;
+    return defaultHost;
   }
   try {
     const url = new URL(trimmed);
@@ -119,6 +124,8 @@ export interface PullRequest {
   /** Platform and host of the connection this PR was fetched through. */
   platform: Platform;
   host: string;
+  /** GitLab only: the project id, required by every project-scoped API call. */
+  projectId?: number;
   number: number;
   title: string;
   html_url: string;

--- a/src/app/services/git-provider.ts
+++ b/src/app/services/git-provider.ts
@@ -5,6 +5,13 @@ export interface ProviderSearchResult {
   incompleteResults: boolean;
 }
 
+/** API failure carrying the HTTP status, so callers can special-case (e.g. best-effort approve). */
+export class ApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
+}
+
 /**
  * Platform-agnostic operations the dashboard needs from a git host.
  *

--- a/src/app/services/gitlab-provider.service.spec.ts
+++ b/src/app/services/gitlab-provider.service.spec.ts
@@ -1,0 +1,275 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
+import { GitLabProviderService } from './gitlab-provider.service';
+import { OrgConnection, PullRequest } from '../models/pull-request.model';
+
+const CONNECTION: OrgConnection = {
+  platform: 'gitlab',
+  host: 'https://gitlab.com',
+  organization: 'my-group',
+  token: 'glpat-test',
+};
+
+function makeMr(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    iid: id * 10,
+    project_id: 42,
+    title: 'Update dependency foo to v2',
+    web_url: `https://gitlab.com/my-group/sub/project/-/merge_requests/${id * 10}`,
+    created_at: '2024-01-01T00:00:00Z',
+    sha: 'sha-1',
+    author: { username: 'renovate-bot', avatar_url: null },
+    ...overrides,
+  };
+}
+
+function makeMrPr(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    id: 1,
+    uid: 'gitlab|https://gitlab.com|1',
+    platform: 'gitlab',
+    host: 'https://gitlab.com',
+    projectId: 42,
+    number: 10,
+    title: 'Update dependency foo to v2',
+    html_url: 'https://gitlab.com/my-group/project/-/merge_requests/10',
+    user: { login: 'renovate-bot', avatar_url: '' },
+    created_at: '2024-01-01T00:00:00Z',
+    labels: [],
+    repoOwner: 'my-group',
+    repoName: 'project',
+    head: { sha: 'sha-1' },
+    isModified: false,
+    ciStatus: 'unknown',
+    checkRuns: [],
+    isProcessing: false,
+    workflowStatus: 'unknown',
+    orgToken: 'glpat-test',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe('GitLabProviderService', () => {
+  let provider: GitLabProviderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+    provider = TestBed.inject(GitLabProviderService);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('searchRenovatePrs', () => {
+    it('queries the group merge_requests API with subgroups and the default author', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse([]));
+
+      await provider.searchRenovatePrs(CONNECTION);
+
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('https://gitlab.com/api/v4/groups/my-group/merge_requests');
+      expect(String(url)).toContain('state=opened');
+      expect(String(url)).toContain('author_username=renovate-bot');
+      expect(String(url)).toContain('include_subgroups=true');
+      expect(String(url)).toContain('scope=all');
+      expect((init as RequestInit).headers).toMatchObject({ 'PRIVATE-TOKEN': 'glpat-test' });
+    });
+
+    it('uses a per-connection author and URL-encodes nested group paths', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse([]));
+
+      await provider.searchRenovatePrs({
+        ...CONNECTION,
+        organization: 'parent/child',
+        renovateAuthor: 'my-renovate',
+      });
+
+      const url = String(fetchSpy.mock.calls[0][0]);
+      expect(url).toContain('/groups/parent%2Fchild/merge_requests');
+      expect(url).toContain('author_username=my-renovate');
+    });
+
+    it('normalizes MRs: uid, iid as number, projectId, and repo path from the web URL', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse([makeMr(7)]));
+
+      const { prs, incompleteResults } = await provider.searchRenovatePrs(CONNECTION);
+
+      expect(incompleteResults).toBe(false);
+      expect(prs).toHaveLength(1);
+      expect(prs[0]).toMatchObject({
+        id: 7,
+        uid: 'gitlab|https://gitlab.com|7',
+        platform: 'gitlab',
+        host: 'https://gitlab.com',
+        projectId: 42,
+        number: 70,
+        repoOwner: 'my-group',
+        repoName: 'sub/project',
+        orgToken: 'glpat-test',
+      });
+    });
+
+    it('paginates until a short page', async () => {
+      const fullPage = Array.from({ length: 100 }, (_, i) => makeMr(i + 1));
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(jsonResponse(fullPage))
+        .mockResolvedValueOnce(jsonResponse([makeMr(101)]));
+
+      const { prs, incompleteResults } = await provider.searchRenovatePrs(CONNECTION);
+
+      expect(prs).toHaveLength(101);
+      expect(incompleteResults).toBe(false);
+    });
+
+    it('caps at 10 pages and flags incomplete results', async () => {
+      const fullPage = Array.from({ length: 100 }, (_, i) => makeMr(i + 1));
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+        Promise.resolve(jsonResponse(fullPage)));
+
+      const { prs, incompleteResults } = await provider.searchRenovatePrs(CONNECTION);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(10);
+      expect(prs).toHaveLength(1000);
+      expect(incompleteResults).toBe(true);
+    });
+
+    it('surfaces GitLab error messages', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        jsonResponse({ message: '401 Unauthorized' }, 401));
+
+      await expect(provider.searchRenovatePrs(CONNECTION)).rejects.toThrow('401 Unauthorized');
+    });
+  });
+
+  describe('fetchPrDetails', () => {
+    it('derives CI status from the head pipeline and maps jobs to check runs', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(jsonResponse(makeMr(1, { head_pipeline: { id: 9, status: 'failed' } })))
+        .mockResolvedValueOnce(jsonResponse([{}, {}])) // 2 commits
+        .mockResolvedValueOnce(jsonResponse([
+          { id: 1, name: 'build', status: 'success', web_url: 'https://gitlab.com/j/1' },
+          { id: 2, name: 'test', status: 'failed', web_url: 'https://gitlab.com/j/2' },
+          { id: 3, name: 'deploy', status: 'manual', web_url: 'https://gitlab.com/j/3' },
+          { id: 4, name: 'lint', status: 'running', web_url: 'https://gitlab.com/j/4' },
+        ]));
+
+      const pr = makeMrPr();
+      await provider.fetchPrDetails(pr);
+
+      expect(pr.ciStatus).toBe('failure');
+      expect(pr.workflowStatus).toBe('failure');
+      expect(pr.commits).toBe(2);
+      expect(pr.isModified).toBe(true);
+      expect(pr.checkRuns).toEqual([
+        { id: 1, name: 'build', status: 'completed', conclusion: 'success', html_url: 'https://gitlab.com/j/1' },
+        { id: 2, name: 'test', status: 'completed', conclusion: 'failure', html_url: 'https://gitlab.com/j/2' },
+        { id: 3, name: 'deploy', status: 'completed', conclusion: 'neutral', html_url: 'https://gitlab.com/j/3' },
+        { id: 4, name: 'lint', status: 'in_progress', conclusion: null, html_url: 'https://gitlab.com/j/4' },
+      ]);
+    });
+
+    it('maps pipeline statuses: running→pending, success→success, no pipeline→unknown', async () => {
+      const cases: [string | undefined, string][] = [
+        ['running', 'pending'],
+        ['created', 'pending'],
+        ['success', 'success'],
+        ['skipped', 'success'],
+        ['canceled', 'failure'],
+        [undefined, 'unknown'],
+      ];
+
+      for (const [pipelineStatus, expected] of cases) {
+        vi.restoreAllMocks();
+        const fetchSpy = vi.spyOn(globalThis, 'fetch')
+          .mockResolvedValueOnce(jsonResponse(makeMr(1, {
+            head_pipeline: pipelineStatus ? { id: 9, status: pipelineStatus } : null,
+          })))
+          .mockResolvedValueOnce(jsonResponse([{}]))
+          .mockResolvedValue(jsonResponse([]));
+
+        const pr = makeMrPr();
+        await provider.fetchPrDetails(pr);
+
+        expect(pr.ciStatus, `pipeline status ${pipelineStatus}`).toBe(expected);
+        void fetchSpy;
+      }
+    });
+
+    it('leaves statuses unknown and never throws when a request fails', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+      const pr = makeMrPr({ ciStatus: 'success', workflowStatus: 'success' });
+      await provider.fetchPrDetails(pr);
+
+      expect(pr.ciStatus).toBe('unknown');
+      expect(pr.workflowStatus).toBe('unknown');
+      expect(pr.checkRuns).toEqual([]);
+    });
+  });
+
+  describe('approveAndMerge', () => {
+    it('approves then merges, squashing multi-commit MRs', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => Promise.resolve(jsonResponse({})));
+
+      await provider.approveAndMerge(makeMrPr({ commits: 3 }));
+
+      const calls = fetchSpy.mock.calls;
+      expect(String(calls[0][0])).toBe('https://gitlab.com/api/v4/projects/42/merge_requests/10/approve');
+      expect(String(calls[1][0])).toBe('https://gitlab.com/api/v4/projects/42/merge_requests/10/merge');
+      expect((calls[1][1] as RequestInit).method).toBe('PUT');
+      expect((calls[1][1] as RequestInit).body).toContain('"squash":true');
+    });
+
+    it('does not squash single-commit MRs', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => Promise.resolve(jsonResponse({})));
+
+      await provider.approveAndMerge(makeMrPr({ commits: 1 }));
+
+      expect((fetchSpy.mock.calls[1][1] as RequestInit).body).toContain('"squash":false');
+    });
+
+    it('merges anyway when approval is unavailable (Premium-only endpoint)', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(jsonResponse({ message: '404 Not Found' }, 404))
+        .mockResolvedValueOnce(jsonResponse({}));
+
+      await provider.approveAndMerge(makeMrPr());
+
+      expect(String(fetchSpy.mock.calls[1][0])).toContain('/merge');
+    });
+
+    it('propagates non-authorization approval failures without merging', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(jsonResponse({ message: 'server exploded' }, 500));
+
+      await expect(provider.approveAndMerge(makeMrPr())).rejects.toThrow('server exploded');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates merge failures', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(jsonResponse({})) // approve ok
+        .mockResolvedValueOnce(jsonResponse({ message: 'Branch cannot be merged' }, 406));
+
+      await expect(provider.approveAndMerge(makeMrPr())).rejects.toThrow('Branch cannot be merged');
+    });
+  });
+
+  describe('close', () => {
+    it('closes the MR with a state_event', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => Promise.resolve(jsonResponse({})));
+
+      await provider.close(makeMrPr());
+
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(String(url)).toBe('https://gitlab.com/api/v4/projects/42/merge_requests/10');
+      expect((init as RequestInit).method).toBe('PUT');
+      expect((init as RequestInit).body).toContain('close');
+    });
+  });
+});

--- a/src/app/services/gitlab-provider.service.ts
+++ b/src/app/services/gitlab-provider.service.ts
@@ -1,0 +1,265 @@
+import { Injectable } from '@angular/core';
+import { CheckRun, CiStatus, OrgConnection, PullRequest } from '../models/pull-request.model';
+import { ApiError, GitProvider, ProviderSearchResult } from './git-provider';
+
+const DEFAULT_RENOVATE_AUTHOR = 'renovate-bot';
+
+/** Shape of a merge request from the GitLab group merge_requests API. */
+interface GitLabMergeRequest {
+  id: number;
+  iid: number;
+  project_id: number;
+  title: string;
+  web_url: string;
+  created_at: string;
+  sha?: string;
+  author: { username: string; avatar_url: string | null };
+  head_pipeline?: { id: number; status: string } | null;
+}
+
+interface GitLabPipelineJob {
+  id: number;
+  name: string;
+  status: string;
+  web_url: string;
+}
+
+/** GitProvider implementation for gitlab.com and self-hosted GitLab (REST v4 API). */
+@Injectable({ providedIn: 'root' })
+export class GitLabProviderService implements GitProvider {
+  async searchRenovatePrs(connection: OrgConnection): Promise<ProviderSearchResult> {
+    const author = connection.renovateAuthor?.trim() || DEFAULT_RENOVATE_AUTHOR;
+    const groupPath = encodeURIComponent(connection.organization);
+    const apiBase = `${connection.host}/api/v4`;
+
+    const prs: PullRequest[] = [];
+    let incompleteResults = false;
+
+    // Plain page loop (a page shorter than per_page means we're done); the
+    // 10-page cap mirrors the GitHub provider's bound on huge result sets.
+    for (let page = 1; page <= 10; page++) {
+      const params = new URLSearchParams({
+        state: 'opened',
+        author_username: author,
+        include_subgroups: 'true',
+        scope: 'all',
+        per_page: '100',
+        page: String(page),
+      });
+      const mrs = await this.apiRequest<GitLabMergeRequest[]>(
+        `${apiBase}/groups/${groupPath}/merge_requests?${params.toString()}`,
+        connection.token,
+      );
+
+      for (const mr of mrs) {
+        prs.push(this.normalizeMr(mr, connection));
+      }
+
+      if (mrs.length < 100) {
+        break;
+      }
+      if (page === 10) {
+        incompleteResults = true; // capped with more results likely remaining
+      }
+    }
+
+    return { prs, incompleteResults };
+  }
+
+  async fetchPrDetails(pr: PullRequest): Promise<void> {
+    const mrBase = this.mrApiBase(pr);
+    try {
+      // MR detail: head SHA and the head pipeline drive the CI status.
+      const mr = await this.apiRequest<GitLabMergeRequest>(mrBase, pr.orgToken);
+      pr.head.sha = mr.sha ?? '';
+      const pipeline = mr.head_pipeline;
+      pr.ciStatus = this.mapPipelineStatus(pipeline?.status);
+      pr.workflowStatus = pr.ciStatus;
+
+      // Commit count (only "more than one?" matters): two entries suffice.
+      const commits = await this.apiRequest<unknown[]>(`${mrBase}/commits?per_page=2`, pr.orgToken);
+      pr.commits = commits.length;
+      pr.isModified = commits.length > 1;
+
+      // Pipeline jobs become the expandable "checks" list.
+      if (pipeline) {
+        const jobs = await this.apiRequest<GitLabPipelineJob[]>(
+          `${pr.host}/api/v4/projects/${pr.projectId}/pipelines/${pipeline.id}/jobs?per_page=100`,
+          pr.orgToken,
+        );
+        pr.checkRuns = jobs.map(job => this.mapJob(job));
+      }
+    } catch (error: unknown) {
+      console.error(`Failed to fetch details for MR !${pr.number}`, error);
+      pr.ciStatus = 'unknown';
+      pr.workflowStatus = 'unknown';
+      pr.checkRuns = [];
+    }
+  }
+
+  async approveAndMerge(pr: PullRequest): Promise<void> {
+    const mrBase = this.mrApiBase(pr);
+
+    // MR approvals are a Premium feature — on Free tiers the endpoint is
+    // absent/forbidden. Approval is best-effort; merging proceeds regardless.
+    try {
+      await this.apiRequest<void>(`${mrBase}/approve`, pr.orgToken, 'POST');
+    } catch (error: unknown) {
+      if (error instanceof ApiError && (error.status === 403 || error.status === 404)) {
+        console.warn(`Approval unavailable for MR !${pr.number} (status ${error.status}); merging without it.`);
+      } else {
+        throw error;
+      }
+    }
+
+    // The project's merge-method settings are enforced server-side; squash
+    // multi-commit MRs to mirror the GitHub provider's behavior.
+    await this.apiRequest<void>(`${mrBase}/merge`, pr.orgToken, 'PUT', {
+      squash: (pr.commits ?? 1) > 1,
+    });
+  }
+
+  async close(pr: PullRequest): Promise<void> {
+    await this.apiRequest<void>(this.mrApiBase(pr), pr.orgToken, 'PUT', { state_event: 'close' });
+  }
+
+  // --- INTERNALS ---
+
+  private normalizeMr(mr: GitLabMergeRequest, connection: OrgConnection): PullRequest {
+    // The project's full path lives in the web URL: <host>/<path>/-/merge_requests/<iid>.
+    // repoOwner is the connection's group (so the org filter matches); repoName
+    // is the remainder of the path (including subgroups).
+    let repoName = `project-${mr.project_id}`;
+    const pathMatch = mr.web_url.match(/^https?:\/\/[^/]+\/(.+?)\/-\/merge_requests\//);
+    if (pathMatch) {
+      const segments = pathMatch[1].split('/');
+      repoName = segments.slice(1).join('/') || segments[0];
+    }
+
+    return {
+      id: mr.id,
+      uid: `${connection.platform}|${connection.host}|${mr.id}`,
+      platform: connection.platform,
+      host: connection.host,
+      projectId: mr.project_id,
+      number: mr.iid,
+      title: mr.title,
+      html_url: mr.web_url,
+      user: { login: mr.author.username, avatar_url: mr.author.avatar_url ?? '' },
+      created_at: mr.created_at,
+      labels: [], // GitLab labels are plain strings; the UI never renders them
+      repoOwner: connection.organization,
+      repoName,
+      head: { sha: mr.sha ?? '' },
+      isModified: false,
+      ciStatus: 'unknown',
+      checkRuns: [],
+      isProcessing: false,
+      workflowStatus: 'unknown',
+      orgToken: connection.token,
+    };
+  }
+
+  private mrApiBase(pr: PullRequest): string {
+    return `${pr.host}/api/v4/projects/${pr.projectId}/merge_requests/${pr.number}`;
+  }
+
+  private mapPipelineStatus(status: string | undefined): CiStatus {
+    switch (status) {
+      case 'success':
+      case 'skipped':
+        return 'success';
+      case 'failed':
+      case 'canceled':
+        return 'failure';
+      case 'running':
+      case 'pending':
+      case 'created':
+      case 'preparing':
+      case 'waiting_for_resource':
+      case 'manual':
+      case 'scheduled':
+        return 'pending';
+      default:
+        return 'unknown';
+    }
+  }
+
+  private mapJob(job: GitLabPipelineJob): CheckRun {
+    let status: CheckRun['status'];
+    let conclusion: CheckRun['conclusion'];
+    switch (job.status) {
+      case 'created':
+      case 'pending':
+      case 'waiting_for_resource':
+      case 'scheduled':
+        status = 'queued';
+        conclusion = null;
+        break;
+      case 'running':
+        status = 'in_progress';
+        conclusion = null;
+        break;
+      case 'success':
+        status = 'completed';
+        conclusion = 'success';
+        break;
+      case 'failed':
+        status = 'completed';
+        conclusion = 'failure';
+        break;
+      case 'canceled':
+        status = 'completed';
+        conclusion = 'cancelled';
+        break;
+      case 'skipped':
+        status = 'completed';
+        conclusion = 'skipped';
+        break;
+      case 'manual':
+        // A manual job neither blocks nor fails the MR.
+        status = 'completed';
+        conclusion = 'neutral';
+        break;
+      default:
+        status = 'completed';
+        conclusion = 'neutral';
+    }
+    return { id: job.id, name: job.name, status, conclusion, html_url: job.web_url };
+  }
+
+  private async apiRequest<T>(url: string, token: string, method = 'GET', body?: object): Promise<T> {
+    const headers: HeadersInit = {
+      'Accept': 'application/json',
+      'PRIVATE-TOKEN': token,
+    };
+    const options: RequestInit = { method, headers };
+    if (body) {
+      options.body = JSON.stringify(body);
+      (options.headers as Record<string, string>)['Content-Type'] = 'application/json';
+    }
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      let errorMessage = response.statusText
+        ? `GitLab API request failed with status: ${response.status} ${response.statusText}`
+        : `GitLab API request failed with status: ${response.status}`;
+      try {
+        const errorData = await response.json();
+        // GitLab errors use either { message } or { error }; message may be an object.
+        const message = errorData.message ?? errorData.error;
+        if (typeof message === 'string') {
+          errorMessage = message;
+        } else if (message) {
+          errorMessage = JSON.stringify(message);
+        }
+      } catch {
+        // Non-JSON body; use the default message
+      }
+      throw new ApiError(errorMessage, response.status);
+    }
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return (await response.json()) as T;
+  }
+}


### PR DESCRIPTION
Phase 3 of multi-platform support (#81): a **GitLab provider** — gitlab.com and self-hosted instances — behind the same `GitProvider` interface, selected per connection.

## `GitLabProviderService` (REST v4)

| Operation | Implementation |
|---|---|
| Search | `GET /groups/:path/merge_requests?state=opened&author_username=…&include_subgroups=true&scope=all` — nested group paths URL-encoded, paginated with the same 10-page cap as the GitHub provider, default author `renovate-bot` (per-connection override from phase 2 applies) |
| Normalize | MRs → shared `PullRequest`: `iid` is the display number, `project_id` captured for project-scoped calls, repo path parsed from the web URL (subgroups included), `uid` = `gitlab\|host\|id` |
| CI status | head-pipeline status mapped: `running/pending/created/manual/…` → pending, `failed/canceled` → failure, `skipped` → success; **pipeline jobs become the expandable check-run list** (statuses/conclusions mapped) |
| Merge | `PUT …/merge` with `squash` for multi-commit MRs (project merge-method settings are enforced server-side) |
| Close | `PUT …` with `state_event: close` |
| Auth | `PRIVATE-TOKEN` header; GitLab's `{message}`/`{error}` bodies surfaced |

**Approve is best-effort** (the open decision from #81, resolved as recommended): MR approvals are a GitLab **Premium** feature, so a 403/404 from `…/approve` logs a warning and the merge proceeds; any other approval failure still aborts. A new `ApiError` carries the HTTP status to make that distinction possible.

## App + UI

- `app.ts` dispatches search/details/actions to the right provider by `platform` — the only change the orchestration needed.
- The add-organization form gains the **GitHub / GitLab platform toggle** (as designed in the original UI demo), with platform-appropriate copy: Group vs Organization, `'api'` vs `'repo'` token scope, gitlab.com host default + note, `renovate-bot` author placeholder. Default hosts are platform-aware throughout (`normalizeHost`, sanitization).
- The switcher trigger icon follows the platform (GitLab mark, GitHub mark, or a neutral globe for mixed setups); GitHub-specific copy generalized.

## Tests

198 total (+20): GitLab search params/auth/encoding/pagination/error surfaces, MR normalization, pipeline-status matrix, job→check-run mapping, squash logic, best-effort approve (404 tolerated / 500 propagated / merge failures propagated), close body, provider dispatch by platform for search and actions, platform-toggle emission + platform-aware duplicate detection + adaptive form copy. `npm run lint`, `npm test`, and `npm run build` all pass.

Verified in the browser: the GitLab add form, a mixed gitlab.com + github.com setup in the switcher (host sublabels, globe trigger icon), and a real request to gitlab.com's API (correctly-formed, surfaced its 401 for the dummy token).

Refs #81 — phase 4 (polish: `!iid` display, per-row platform icons, README/token docs, contract tests) is the remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
