### PR TITLE
Multi-platform polish: platform-neutral errors, !iid refs, docs, contract tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Renovate PR Dashboard
 
+A browser-only dashboard for open [Renovate](https://docs.renovatebot.com/) pull requests, grouped by update across all of your organizations. Supports **github.com**, **GitHub Enterprise Server**, **gitlab.com**, and **self-hosted GitLab** — configure any mix of connections from the organization switcher in the sidebar.
+
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 21.1.1.
 
 ## Development server
@@ -62,9 +64,11 @@ To run a single test file:
 npx ng test --include src/app/path/to/file.spec.ts
 ```
 
-## GitHub token scopes
+## Connections and access tokens
 
-The app requires a GitHub personal access token (PAT). The token field accepts:
+Each connection needs an organization (GitHub) or group (GitLab) and a personal access token. Tokens are kept in `sessionStorage` only — they are cleared when the tab closes and are never sent anywhere except the configured instance.
+
+### GitHub (github.com and GitHub Enterprise Server)
 
 **Classic PAT** — enable these scopes:
 - `repo` — read repository and pull request data
@@ -75,6 +79,18 @@ The app requires a GitHub personal access token (PAT). The token field accepts:
 - `Pull requests: Write`
 - `Checks: Read`
 - `Metadata: Read`
+
+For **GitHub Enterprise Server**, set the instance URL in the add-organization form under *Advanced → Server URL* (the API is reached at `<server>/api/v3`). If Renovate runs self-hosted (on GHES it always does), also set *Advanced → Renovate bot author* to the bot's login — the default `app/renovate` only matches the hosted GitHub App.
+
+### GitLab (gitlab.com and self-hosted)
+
+Use a personal access token with the `api` scope, created by a user with at least **Developer** access to the group (merging requires it). The group field accepts nested paths (e.g. `parent/child`), and merge requests from subgroups are included automatically.
+
+The default Renovate author is `renovate-bot` (the hosted app on gitlab.com); for self-hosted Renovate set *Advanced → Renovate bot author* to your bot's username. Note that approving MRs from the dashboard requires a GitLab Premium tier — on Free, "Approve & Merge" skips the approval step and merges directly.
+
+### Private instances
+
+The dashboard runs entirely in your browser, so your browser must be able to reach the instance (a VPN is fine). One caveat: a page served over HTTPS (like the GitHub Pages deployment) cannot call an `http://`-only instance — browsers block mixed content. In that case run the dashboard locally, or serve your instance over TLS.
 
 ## Additional Resources
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -131,7 +131,7 @@
             <svg class="w-4 h-4 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
             </svg>
-            <span><strong class="font-semibold">Incomplete results:</strong> The GitHub Search API returned partial results — some PRs may be missing. Try your search again.</span>
+            <span><strong class="font-semibold">Incomplete results:</strong> One or more searches failed or returned partial results — some PRs may be missing. Try refreshing.</span>
           </div>
         }
 

--- a/src/app/components/org-switcher/org-switcher.component.html
+++ b/src/app/components/org-switcher/org-switcher.component.html
@@ -10,7 +10,8 @@
   class="flex w-full items-center gap-2.5 rounded-md border border-edge bg-page px-3 py-2.5 transition-colors duration-200 hover:bg-ghost focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
 >
   <span
-    class="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-gradient-to-br from-slate-600 to-slate-800 text-xs font-bold text-white"
+    class="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-gradient-to-br text-xs font-bold text-white"
+    [class]="triggerAvatarClass()"
     aria-hidden="true"
   >{{ avatarInitial() }}</span>
   <span class="min-w-0 flex-1 text-left">
@@ -110,7 +111,8 @@
                 [attr.aria-label]="'Show only ' + conn.organization"
               >
                 <span
-                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-gradient-to-br from-slate-600 to-slate-800 text-[11px] font-bold text-white"
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-gradient-to-br text-[11px] font-bold text-white"
+                  [class]="avatarClass(conn.platform)"
                   aria-hidden="true"
                 >{{ conn.organization.charAt(0).toUpperCase() }}</span>
                 <span class="min-w-0 flex-1 text-left">
@@ -126,7 +128,8 @@
             } @else {
               <span class="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-2">
                 <span
-                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-gradient-to-br from-slate-600 to-slate-800 text-[11px] font-bold text-white"
+                  class="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-gradient-to-br text-[11px] font-bold text-white"
+                  [class]="avatarClass(conn.platform)"
                   aria-hidden="true"
                 >{{ conn.organization.charAt(0).toUpperCase() }}</span>
                 <span class="min-w-0 flex-1">

--- a/src/app/components/org-switcher/org-switcher.component.ts
+++ b/src/app/components/org-switcher/org-switcher.component.ts
@@ -115,6 +115,13 @@ export class OrgSwitcherComponent {
   /** The org filter is only meaningful with more than one configured org. */
   showSelection = computed(() => this.connections().length > 1);
 
+  /** Avatar gradient by platform (GitLab orange, GitHub slate — as in the design demo). */
+  avatarClass(platform: Platform): string {
+    return platform === 'gitlab' ? 'from-orange-500 to-orange-700' : 'from-slate-600 to-slate-800';
+  }
+
+  triggerAvatarClass = computed(() => this.avatarClass(this.triggerPlatform() ?? 'github'));
+
   /** Compact display form of a connection host, e.g. 'ghes.example.com'. */
   hostLabel(host: string): string {
     try {

--- a/src/app/components/pr-item/pr-item.component.html
+++ b/src/app/components/pr-item/pr-item.component.html
@@ -8,7 +8,7 @@
         class="flex items-center gap-2 text-left shrink-0"
         (click)="onToggleExpanded()"
         [attr.aria-expanded]="expanded()"
-        [attr.aria-label]="'Toggle details for ' + pr().repoOwner + '/' + pr().repoName + '#' + pr().number"
+        [attr.aria-label]="'Toggle details for ' + prRef()"
       >
         <svg
           class="w-4 h-4 text-ink-3 transition-transform duration-200 shrink-0"
@@ -28,7 +28,7 @@
           rel="noopener noreferrer"
           class="font-mono text-xs text-accent hover:underline truncate block"
         >
-          {{ pr().repoOwner }}/{{ pr().repoName }}#{{ pr().number }}
+          {{ prRef() }}
         </a>
         @if (pr().isModified) {
           <span class="inline-flex items-center gap-1 mt-0.5 text-xs bg-amber-500/15 text-amber-400 font-medium px-1.5 py-0.5 rounded-md">
@@ -98,7 +98,7 @@
     <button
       (click)="onClosePr()"
       [disabled]="pr().isProcessing"
-      [attr.aria-label]="'Close PR ' + pr().repoOwner + '/' + pr().repoName + '#' + pr().number"
+      [attr.aria-label]="'Close PR ' + prRef()"
       class="px-3 py-1.5 text-xs font-medium rounded-md border border-edge text-ink-2 hover:bg-ghost disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200"
     >
       @if (pr().isProcessing) {
@@ -110,7 +110,7 @@
     <button
       (click)="onApproveAndMergePr()"
       [disabled]="isMergeDisabled"
-      [attr.aria-label]="'Approve and merge PR ' + pr().repoOwner + '/' + pr().repoName + '#' + pr().number"
+      [attr.aria-label]="'Approve and merge PR ' + prRef()"
       class="px-3 py-1.5 text-xs font-medium rounded-md bg-accent text-white hover:bg-accent-hover disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-200"
     >
       @if (pr().isProcessing) {

--- a/src/app/components/pr-item/pr-item.component.spec.ts
+++ b/src/app/components/pr-item/pr-item.component.spec.ts
@@ -151,6 +151,24 @@ describe('PrItemComponent', () => {
     });
   });
 
+  describe('prRef', () => {
+    it('formats GitHub PRs with # and GitLab MRs with !', () => {
+      const fixture = TestBed.createComponent(PrItemComponent);
+
+      fixture.componentRef.setInput('pr', makePr());
+      fixture.detectChanges();
+      expect(fixture.componentInstance.prRef()).toBe('test-org/test-repo#42');
+      expect(fixture.nativeElement.textContent).toContain('test-org/test-repo#42');
+
+      fixture.componentRef.setInput('pr', makePr({
+        platform: 'gitlab', host: 'https://gitlab.com', uid: 'gitlab|https://gitlab.com|1',
+      }));
+      fixture.detectChanges();
+      expect(fixture.componentInstance.prRef()).toBe('test-org/test-repo!42');
+      expect(fixture.nativeElement.textContent).toContain('test-org/test-repo!42');
+    });
+  });
+
   describe('checks progress', () => {
     function makeCheck(id: number, conclusion: 'success' | 'failure' | 'skipped' | 'neutral' | null) {
       return { id, name: `check-${id}`, status: 'completed' as const, conclusion, html_url: '' };

--- a/src/app/components/pr-item/pr-item.component.ts
+++ b/src/app/components/pr-item/pr-item.component.ts
@@ -20,6 +20,13 @@ export class PrItemComponent {
     return this.pr().isProcessing || this.pr().workflowStatus === 'failure';
   }
 
+  /** Platform-style reference: org/repo#42 for GitHub PRs, group/project!42 for GitLab MRs. */
+  prRef = computed(() => {
+    const pr = this.pr();
+    const separator = pr.platform === 'gitlab' ? '!' : '#';
+    return `${pr.repoOwner}/${pr.repoName}${separator}${pr.number}`;
+  });
+
   checksTotal = computed(() => this.pr().checkRuns.length);
 
   checksPassed = computed(() =>

--- a/src/app/services/git-provider.contract.spec.ts
+++ b/src/app/services/git-provider.contract.spec.ts
@@ -1,0 +1,162 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
+import { GitProvider } from './git-provider';
+import { GitHubProviderService } from './github-provider.service';
+import { GitLabProviderService } from './gitlab-provider.service';
+import { connectionKey, OrgConnection, prConnectionKey, PullRequest } from '../models/pull-request.model';
+
+/**
+ * Behavioral contract every GitProvider implementation must satisfy, run
+ * against each provider with platform-appropriate fetch fixtures. This keeps
+ * the implementations from drifting apart on the invariants app.ts relies on.
+ */
+interface ProviderContract {
+  name: string;
+  providerType: new (...args: never[]) => GitProvider;
+  connection: OrgConnection;
+  /** One search response body containing exactly one result item. */
+  searchBody: unknown;
+  /** A PR of this platform, as if returned by searchRenovatePrs. */
+  makePr(): PullRequest;
+}
+
+const CONTRACTS: ProviderContract[] = [
+  {
+    name: 'GitHubProviderService',
+    providerType: GitHubProviderService,
+    connection: { platform: 'github', host: 'https://github.com', organization: 'my-org', token: 'tok' },
+    searchBody: {
+      total_count: 1,
+      incomplete_results: false,
+      items: [{
+        id: 11,
+        number: 5,
+        title: 'Update dependency foo to v2',
+        repository_url: 'https://api.github.com/repos/my-org/repo',
+        html_url: 'https://github.com/my-org/repo/pull/5',
+        user: { login: 'renovate[bot]', avatar_url: '' },
+        created_at: '2024-01-01T00:00:00Z',
+        labels: [],
+      }],
+    },
+    makePr: () => ({
+      id: 11, uid: 'github|https://github.com|11', platform: 'github', host: 'https://github.com',
+      number: 5, title: 'Update dependency foo to v2', html_url: 'https://github.com/my-org/repo/pull/5',
+      user: { login: 'renovate[bot]', avatar_url: '' }, created_at: '2024-01-01T00:00:00Z', labels: [],
+      repoOwner: 'my-org', repoName: 'repo', head: { sha: 'abc' }, isModified: false,
+      ciStatus: 'unknown', checkRuns: [], isProcessing: false, workflowStatus: 'unknown',
+      orgToken: 'tok', commits: 1, allowMergeCommit: true,
+    }),
+  },
+  {
+    name: 'GitLabProviderService',
+    providerType: GitLabProviderService,
+    connection: { platform: 'gitlab', host: 'https://gitlab.com', organization: 'my-org', token: 'tok' },
+    searchBody: [{
+      id: 11,
+      iid: 5,
+      project_id: 42,
+      title: 'Update dependency foo to v2',
+      web_url: 'https://gitlab.com/my-org/repo/-/merge_requests/5',
+      created_at: '2024-01-01T00:00:00Z',
+      sha: 'abc',
+      author: { username: 'renovate-bot', avatar_url: null },
+    }],
+    makePr: () => ({
+      id: 11, uid: 'gitlab|https://gitlab.com|11', platform: 'gitlab', host: 'https://gitlab.com',
+      projectId: 42, number: 5, title: 'Update dependency foo to v2',
+      html_url: 'https://gitlab.com/my-org/repo/-/merge_requests/5',
+      user: { login: 'renovate-bot', avatar_url: '' }, created_at: '2024-01-01T00:00:00Z', labels: [],
+      repoOwner: 'my-org', repoName: 'repo', head: { sha: 'abc' }, isModified: false,
+      ciStatus: 'unknown', checkRuns: [], isProcessing: false, workflowStatus: 'unknown',
+      orgToken: 'tok', commits: 1,
+    }),
+  },
+];
+
+for (const contract of CONTRACTS) {
+  describe(`GitProvider contract: ${contract.name}`, () => {
+    let provider: GitProvider;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
+      provider = TestBed.inject(contract.providerType);
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    it('search returns normalized PRs matching the connection identity', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(contract.searchBody), { status: 200 }));
+
+      const result = await provider.searchRenovatePrs(contract.connection);
+
+      expect(typeof result.incompleteResults).toBe('boolean');
+      expect(result.prs).toHaveLength(1);
+      const pr = result.prs[0];
+      expect(pr.platform).toBe(contract.connection.platform);
+      expect(pr.host).toBe(contract.connection.host);
+      expect(pr.uid).toBe(`${pr.platform}|${pr.host}|${pr.id}`);
+      expect(pr.orgToken).toBe(contract.connection.token);
+      expect(pr.title.length).toBeGreaterThan(0);
+      expect(pr.number).toBeGreaterThan(0);
+      // The org filter must be able to match this PR back to its connection.
+      expect(prConnectionKey(pr)).toBe(connectionKey(contract.connection));
+    });
+
+    it('search requests only touch the connection host', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(contract.searchBody), { status: 200 }));
+
+      await provider.searchRenovatePrs(contract.connection);
+
+      const expectedOrigin = contract.connection.host === 'https://github.com'
+        ? 'https://api.github.com'
+        : contract.connection.host;
+      for (const call of fetchSpy.mock.calls) {
+        expect(String(call[0]).startsWith(expectedOrigin)).toBe(true);
+      }
+    });
+
+    it('search propagates failures as errors', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 500 }));
+
+      await expect(provider.searchRenovatePrs(contract.connection)).rejects.toThrow();
+    });
+
+    it('fetchPrDetails never throws and degrades statuses to unknown on failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+      const pr = contract.makePr();
+      pr.ciStatus = 'success';
+      pr.workflowStatus = 'success';
+      await provider.fetchPrDetails(pr);
+
+      expect(pr.ciStatus).toBe('unknown');
+      expect(pr.workflowStatus).toBe('unknown');
+      expect(pr.checkRuns).toEqual([]);
+    });
+
+    it('approveAndMerge rejects when the merge fails', async () => {
+      // First call (approve) succeeds, second (merge) fails.
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'merge blocked' }), { status: 405 }));
+
+      await expect(provider.approveAndMerge(contract.makePr())).rejects.toThrow();
+    });
+
+    it('close resolves and only touches the PR host', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await provider.close(contract.makePr());
+
+      expect(fetchSpy).toHaveBeenCalled();
+      const expectedOrigin = contract.connection.host === 'https://github.com'
+        ? 'https://api.github.com'
+        : contract.connection.host;
+      expect(String(fetchSpy.mock.calls[0][0]).startsWith(expectedOrigin)).toBe(true);
+    });
+  });
+}


### PR DESCRIPTION
Phase 4 — the final phase — of multi-platform support (#81), including the fix for the misleading error banner reported after the first real GitLab test.

## The reported bug

The **incomplete-results banner** was hardcoded to say "The GitHub Search API returned partial results…". Any transient search failure on a GitLab connection takes the same partial-failure path (`Promise.allSettled` → rejected org → `incompleteResults`), so GitLab users saw a GitHub error. The message is now platform-neutral: *"One or more searches failed or returned partial results — some PRs may be missing. Try refreshing."*

## Polish

- **`!iid` references**: GitLab MRs render as `group/project!5` (their platform-native form) in the PR row link and its aria-labels, via a `prRef` computed; GitHub PRs keep `#`.
- **Platform-colored avatars** in the org switcher (GitLab orange, GitHub slate — the design demo's convention) on both the trigger and connection rows, making mixed setups scannable at a glance.
- **README**: multi-platform intro; per-platform access-token documentation (GitHub classic + fine-grained scopes; GitLab `api` scope and the Developer-role requirement for merging; GHES Server URL + self-hosted Renovate author note; GitLab Free approve behavior); and the private-instance reachability / mixed-content caveat.

## Contract tests

New `git-provider.contract.spec.ts` runs one shared suite of behavioral invariants against **both** providers with platform-appropriate fixtures:

- search results carry the normalized identity fields the org filter depends on (`prConnectionKey(pr) === connectionKey(connection)`), plus `uid`/token propagation;
- all requests stay on the connection's host;
- search failures propagate as errors;
- `fetchPrDetails` never throws and degrades statuses to `unknown`;
- `approveAndMerge` rejects when the merge fails.

This is the drift-prevention net for any future provider work.

## Tests

211 total (+13). `npm run lint`, `npm test`, and `npm run build` all pass; verified the avatar colors and banner in the browser with a mixed gitlab.com + github.com setup.

Closes #81 🎉 — with this, the dashboard supports github.com, GitHub Enterprise Server, gitlab.com, and self-hosted GitLab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
