### PR TITLE
Cache repo merge settings per repository in the GitHub provider

### DIFF
--- a/src/app/services/github-provider.service.spec.ts
+++ b/src/app/services/github-provider.service.spec.ts
@@ -263,6 +263,65 @@ describe('GitHubProviderService', () => {
     });
   });
 
+  describe('repo settings cache', () => {
+    function routeFetch(counters: { repo: number }) {
+      return vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+        const u = String(url);
+        if (/\/repos\/[^/]+\/[^/]+$/.test(u)) {
+          counters.repo++;
+          return Promise.resolve(jsonResponse({ allow_squash_merge: true, allow_merge_commit: true, allow_rebase_merge: true }));
+        }
+        if (u.includes('/pulls/')) {
+          return Promise.resolve(jsonResponse({ commits: 1, head: { sha: 'sha-1' } }));
+        }
+        if (u.includes('/status')) {
+          return Promise.resolve(jsonResponse({ state: 'success' }));
+        }
+        return Promise.resolve(jsonResponse({ total_count: 0, check_runs: [] }));
+      });
+    }
+
+    it('fetches repo settings once per repository across PRs', async () => {
+      const counters = { repo: 0 };
+      routeFetch(counters);
+
+      await provider.fetchPrDetails(makePr({ id: 1, number: 1 }));
+      await provider.fetchPrDetails(makePr({ id: 2, number: 2 }));
+      await provider.fetchPrDetails(makePr({ id: 3, number: 3, repoName: 'other-repo' }));
+
+      expect(counters.repo).toBe(2); // once for repo, once for other-repo
+    });
+
+    it('does not cache failed settings fetches', async () => {
+      let calls = 0;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+        const u = String(url);
+        if (/\/repos\/[^/]+\/[^/]+$/.test(u)) {
+          calls++;
+          return calls === 1
+            ? Promise.resolve(new Response('{}', { status: 500 }))
+            : Promise.resolve(jsonResponse({ allow_squash_merge: true, allow_merge_commit: true, allow_rebase_merge: true }));
+        }
+        if (u.includes('/pulls/')) {
+          return Promise.resolve(jsonResponse({ commits: 1, head: { sha: 'sha-1' } }));
+        }
+        if (u.includes('/status')) {
+          return Promise.resolve(jsonResponse({ state: 'success' }));
+        }
+        return Promise.resolve(jsonResponse({ total_count: 0, check_runs: [] }));
+      });
+
+      const first = makePr({ id: 1, number: 1 });
+      await provider.fetchPrDetails(first); // settings fetch fails → statuses unknown
+      expect(first.ciStatus).toBe('unknown');
+
+      const second = makePr({ id: 2, number: 2 });
+      await provider.fetchPrDetails(second); // retried, not served from cache
+      expect(calls).toBe(2);
+      expect(second.allowSquashMerge).toBe(true);
+    });
+  });
+
   describe('approveAndMerge', () => {
     it('approves and then merges with the determined method', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));

--- a/src/app/services/github-provider.service.ts
+++ b/src/app/services/github-provider.service.ts
@@ -27,6 +27,11 @@ export function githubApiBase(host: string): string {
 /** GitProvider implementation for github.com and GitHub Enterprise Server (REST v3 API). */
 @Injectable({ providedIn: 'root' })
 export class GitHubProviderService implements GitProvider {
+  // Repo merge settings are identical for every PR of a repo and rarely
+  // change, so cache them for the service lifetime instead of fetching once
+  // per PR. Storing the promise (not the value) also dedupes concurrent
+  // fetches within a detail batch.
+  private repoSettingsCache = new Map<string, Promise<GitHubRepository>>();
   async searchRenovatePrs(connection: OrgConnection): Promise<ProviderSearchResult> {
     const author = connection.renovateAuthor?.trim() || DEFAULT_RENOVATE_AUTHOR;
     const query = `is:pr author:${author} org:${connection.organization} is:open`;
@@ -80,8 +85,7 @@ export class GitHubProviderService implements GitProvider {
       pr.commits = prData.commits;
 
       // Get repository settings to determine allowed merge methods
-      const repoUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}`;
-      const repoData = await this.apiRequest<GitHubRepository>(repoUrl, pr.orgToken);
+      const repoData = await this.getRepoSettings(pr);
       pr.allowSquashMerge = repoData.allow_squash_merge;
       pr.allowMergeCommit = repoData.allow_merge_commit;
       pr.allowRebaseMerge = repoData.allow_rebase_merge;
@@ -149,6 +153,19 @@ export class GitHubProviderService implements GitProvider {
   }
 
   // --- INTERNALS ---
+
+  private getRepoSettings(pr: PullRequest): Promise<GitHubRepository> {
+    const key = `${pr.host}|${pr.repoOwner}/${pr.repoName}`;
+    let settings = this.repoSettingsCache.get(key);
+    if (!settings) {
+      const repoUrl = `${githubApiBase(pr.host)}/repos/${pr.repoOwner}/${pr.repoName}`;
+      settings = this.apiRequest<GitHubRepository>(repoUrl, pr.orgToken);
+      this.repoSettingsCache.set(key, settings);
+      // Don't cache failures — the next PR of this repo should retry.
+      settings.catch(() => this.repoSettingsCache.delete(key));
+    }
+    return settings;
+  }
 
   private async fetchAllSearchItems(host: string, query: string, token: string): Promise<{ items: GitHubIssueSearchItem[]; incompleteResults: boolean }> {
     const headers = {


### PR DESCRIPTION
Fixes the remaining half of #23: `fetchPrDetails` fetched the repo's merge settings (`allow_squash_merge` / `allow_merge_commit` / `allow_rebase_merge`) **once per PR**, so 50 Renovate PRs across 5 repos meant 50 identical settings calls where 5 suffice.

The GitHub provider now caches the settings **promise** per `host|owner/repo` for the service lifetime — storing the promise (not the value) also dedupes concurrent fetches within a detail batch, and failed fetches are evicted so the next PR of that repo retries rather than being served a cached rejection.

The issue's other item (debouncing the search trigger) was already resolved by #77 (auto-search, refresh disabled while loading, generation guard) — noted on the issue.

**Tests:** cache-hit counting across PRs of the same/different repos, and failure non-caching. 200 tests, lint, and build pass.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)