### PR TITLE
Replace [innerHTML] icon injection with components; finish a11y gaps

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -117,7 +117,7 @@
 
         <!-- Error -->
         @if (error()) {
-          <div class="flex items-start gap-3 px-4 py-3 rounded-lg bg-rose-500/10 border border-rose-500/30 text-rose-400 text-sm">
+          <div role="alert" class="flex items-start gap-3 px-4 py-3 rounded-lg bg-rose-500/10 border border-rose-500/30 text-rose-400 text-sm">
             <svg class="w-4 h-4 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <circle cx="12" cy="12" r="10"/><path stroke-linecap="round" d="M12 8v4m0 4h.01"/>
             </svg>
@@ -127,7 +127,7 @@
 
         <!-- Incomplete results -->
         @if (incompleteResults()) {
-          <div class="flex items-start gap-3 px-4 py-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-400 text-sm">
+          <div role="status" class="flex items-start gap-3 px-4 py-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-400 text-sm">
             <svg class="w-4 h-4 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
             </svg>
@@ -174,7 +174,7 @@
 
         <!-- Loading -->
         @if (isLoading() && prGroups().length === 0) {
-          <div class="flex flex-col items-center justify-center py-16 text-ink-3">
+          <div role="status" aria-live="polite" class="flex flex-col items-center justify-center py-16 text-ink-3">
             <svg class="animate-spin w-6 h-6 mb-3" fill="none" viewBox="0 0 24 24" aria-hidden="true">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
               <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -479,6 +479,26 @@ describe('App', () => {
     });
   });
 
+  describe('live regions', () => {
+    it('marks the error banner as an alert', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.componentInstance.error.set('boom');
+      fixture.detectChanges();
+
+      const alert = fixture.nativeElement.querySelector('[role="alert"]') as HTMLElement;
+      expect(alert?.textContent).toContain('boom');
+    });
+
+    it('announces the loading state politely', () => {
+      const fixture = TestBed.createComponent(App);
+      fixture.componentInstance.isLoading.set(true);
+      fixture.detectChanges();
+
+      const status = fixture.nativeElement.querySelector('[role="status"][aria-live="polite"]') as HTMLElement;
+      expect(status?.textContent).toContain('Fetching Renovate pull requests');
+    });
+  });
+
   describe('darkMode', () => {
     beforeEach(() => localStorage.clear());
     afterEach(() => localStorage.clear());

--- a/src/app/components/icons/status-icons.component.spec.ts
+++ b/src/app/components/icons/status-icons.component.spec.ts
@@ -1,0 +1,92 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  CheckRunConclusionIconComponent,
+  CheckRunStatusIconComponent,
+  CiStatusIconComponent,
+} from './status-icons.component';
+
+describe('CiStatusIconComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CiStatusIconComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+  });
+
+  function create(status: string, label: string | null = null) {
+    const fixture = TestBed.createComponent(CiStatusIconComponent);
+    fixture.componentRef.setInput('status', status);
+    fixture.componentRef.setInput('label', label);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders a distinct icon per status', () => {
+    expect(create('success').nativeElement.querySelector('svg.text-emerald-500')).not.toBeNull();
+    expect(create('failure').nativeElement.querySelector('svg.text-rose-500')).not.toBeNull();
+    expect(create('pending').nativeElement.querySelector('svg.animate-spin')).not.toBeNull();
+    expect(create('mixed').nativeElement.querySelector('svg.text-ink-3')).not.toBeNull();
+    expect(create('unknown').nativeElement.querySelector('svg.text-ink-3')).not.toBeNull();
+  });
+
+  it('is an accessible image when labeled and hidden otherwise', () => {
+    const labeled = create('success', 'CI status: success');
+    const host = labeled.nativeElement as HTMLElement;
+    expect(host.getAttribute('role')).toBe('img');
+    expect(host.getAttribute('aria-label')).toBe('CI status: success');
+    expect(host.getAttribute('aria-hidden')).toBeNull();
+
+    const decorative = create('success').nativeElement as HTMLElement;
+    expect(decorative.getAttribute('aria-hidden')).toBe('true');
+    expect(decorative.getAttribute('role')).toBeNull();
+  });
+});
+
+describe('CheckRunStatusIconComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CheckRunStatusIconComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+  });
+
+  it('renders queued, in-progress, and completed variants', () => {
+    for (const [status, selector] of [
+      ['queued', 'svg.text-blue-400'],
+      ['in_progress', 'svg.animate-spin'],
+      ['completed', 'svg.text-green-400'],
+    ] as const) {
+      const fixture = TestBed.createComponent(CheckRunStatusIconComponent);
+      fixture.componentRef.setInput('status', status);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector(selector), status).not.toBeNull();
+    }
+  });
+});
+
+describe('CheckRunConclusionIconComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CheckRunConclusionIconComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+  });
+
+  it('groups conclusions into success / failure / neutral variants', () => {
+    for (const [conclusion, selector] of [
+      ['success', 'svg.text-green-500'],
+      ['failure', 'svg.text-red-500'],
+      ['timed_out', 'svg.text-red-500'],
+      ['action_required', 'svg.text-red-500'],
+      ['cancelled', 'svg.text-gray-400'],
+      ['skipped', 'svg.text-gray-400'],
+      ['neutral', 'svg.text-gray-400'],
+    ] as const) {
+      const fixture = TestBed.createComponent(CheckRunConclusionIconComponent);
+      fixture.componentRef.setInput('conclusion', conclusion);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector(selector), conclusion).not.toBeNull();
+    }
+  });
+});

--- a/src/app/components/icons/status-icons.component.ts
+++ b/src/app/components/icons/status-icons.component.ts
@@ -1,0 +1,133 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CheckRun, PrGroup } from '../../models/pull-request.model';
+
+/**
+ * Status icons as real components (replacing the [innerHTML] string-injection
+ * pattern): template-checked, deduplicated, and screen-reader friendly. Each
+ * exposes an optional `label`; without one the icon is decorative
+ * (aria-hidden).
+ */
+
+@Component({
+  selector: 'app-ci-status-icon',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'inline-flex shrink-0',
+    '[attr.role]': "label() ? 'img' : null",
+    '[attr.aria-label]': 'label()',
+    '[attr.aria-hidden]': 'label() ? null : true',
+    '[attr.title]': 'label()',
+  },
+  template: `
+    @switch (status()) {
+      @case ('success') {
+        <svg class="w-5 h-5 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+      }
+      @case ('failure') {
+        <svg class="w-5 h-5 text-rose-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+      }
+      @case ('pending') {
+        <svg class="w-5 h-5 text-amber-400 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+        </svg>
+      }
+      @default {
+        <!-- mixed / unknown -->
+        <svg class="w-5 h-5 text-ink-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+      }
+    }
+  `,
+})
+export class CiStatusIconComponent {
+  status = input.required<PrGroup['aggregateCiStatus']>();
+  label = input<string | null>(null);
+}
+
+@Component({
+  selector: 'app-check-run-status-icon',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'inline-flex shrink-0', 'aria-hidden': 'true' },
+  template: `
+    @switch (status()) {
+      @case ('queued') {
+        <svg class="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8h2a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V10a2 2 0 012-2h2"/>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 12v9m0-9a4 4 0 100-8h0a4 4 0 000 8z"/>
+        </svg>
+      }
+      @case ('in_progress') {
+        <svg class="w-4 h-4 text-yellow-400 animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V2C5.373 2 1 6.373 1 12h3zm2 5.291A7.962 7.962 0 014 12H1c0 3.042 1.135 5.824 3 7.938l2-2.647z"/>
+        </svg>
+      }
+      @default {
+        <!-- completed -->
+        <svg class="w-4 h-4 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414 0L9 11.586 6.707 9.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l7-7a1 1 0 000-1.414z" clip-rule="evenodd"/>
+        </svg>
+      }
+    }
+  `,
+})
+export class CheckRunStatusIconComponent {
+  status = input.required<CheckRun['status']>();
+}
+
+@Component({
+  selector: 'app-check-run-conclusion-icon',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'inline-flex shrink-0', 'aria-hidden': 'true' },
+  template: `
+    @switch (conclusionGroup()) {
+      @case ('success') {
+        <svg class="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+        </svg>
+      }
+      @case ('failure') {
+        <svg class="w-4 h-4 text-red-500" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+        </svg>
+      }
+      @case ('neutral') {
+        <svg class="w-4 h-4 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"/>
+        </svg>
+      }
+      @default {
+        <svg class="w-4 h-4 text-gray-500" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+        </svg>
+      }
+    }
+  `,
+})
+export class CheckRunConclusionIconComponent {
+  conclusion = input.required<CheckRun['conclusion']>();
+
+  /** Collapse the many conclusion values into the four visual groups. */
+  conclusionGroup(): 'success' | 'failure' | 'neutral' | 'unknown' {
+    switch (this.conclusion()) {
+      case 'success':
+        return 'success';
+      case 'failure':
+      case 'timed_out':
+      case 'action_required':
+        return 'failure';
+      case 'cancelled':
+      case 'neutral':
+      case 'skipped':
+        return 'neutral';
+      default:
+        return 'unknown';
+    }
+  }
+}

--- a/src/app/components/pr-group/pr-group.component.html
+++ b/src/app/components/pr-group/pr-group.component.html
@@ -8,8 +8,9 @@
       class="flex items-center gap-2.5 flex-1 min-w-0 text-left group"
       (click)="onToggleGroup()"
       [attr.aria-expanded]="group().isExpanded"
+      [attr.aria-controls]="group().isExpanded ? panelId() : null"
     >
-      <span [innerHTML]="getCIStatusIcon(group().aggregateCiStatus)" class="shrink-0"></span>
+      <app-ci-status-icon class="shrink-0" [status]="group().aggregateCiStatus" [label]="ciStatusLabel()" />
       <span class="text-sm font-medium text-ink group-hover:text-accent truncate transition-colors duration-200 pr-1">{{ group().title }}</span>
       <svg
         class="w-4 h-4 text-ink-3 shrink-0 transition-transform duration-200"
@@ -90,7 +91,7 @@
 
   <!-- Expanded PR list -->
   @if (group().isExpanded) {
-    <div class="border-t border-edge divide-y divide-edge">
+    <div class="border-t border-edge divide-y divide-edge" [id]="panelId()" role="region" [attr.aria-label]="'Pull requests in group: ' + group().title">
       @for (pr of group().prs; track pr.uid) {
         <app-pr-item
           [pr]="pr"

--- a/src/app/components/pr-group/pr-group.component.spec.ts
+++ b/src/app/components/pr-group/pr-group.component.spec.ts
@@ -206,4 +206,32 @@ describe('PrGroupComponent', () => {
       expect(btn.querySelector('svg')?.classList.contains('animate-spin')).toBe(true);
     });
   });
+
+  describe('accessibility', () => {
+    it('links the toggle to the expanded region via aria-controls', () => {
+      const fixture = TestBed.createComponent(PrGroupComponent);
+      fixture.componentRef.setInput('group', makeGroup({
+        title: 'Update dependency foo to v2',
+        prs: [makePr()],
+        isExpanded: true,
+      }));
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('button[aria-expanded]') as HTMLButtonElement;
+      const controls = toggle.getAttribute('aria-controls');
+      expect(controls).toBe('group-panel-update-dependency-foo-to-v2');
+      const region = fixture.nativeElement.querySelector(`#${controls}`) as HTMLElement;
+      expect(region).not.toBeNull();
+      expect(region.getAttribute('role')).toBe('region');
+    });
+
+    it('omits aria-controls while collapsed', () => {
+      const fixture = TestBed.createComponent(PrGroupComponent);
+      fixture.componentRef.setInput('group', makeGroup({ prs: [makePr()], isExpanded: false }));
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('button[aria-expanded]') as HTMLButtonElement;
+      expect(toggle.getAttribute('aria-controls')).toBeNull();
+    });
+  });
 });

--- a/src/app/components/pr-group/pr-group.component.ts
+++ b/src/app/components/pr-group/pr-group.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { PrGroup, PullRequest } from '../../models/pull-request.model';
 import { PrItemComponent } from '../pr-item/pr-item.component';
+import { CiStatusIconComponent } from '../icons/status-icons.component';
 
 @Component({
   selector: 'app-pr-group',
-  imports: [PrItemComponent],
+  imports: [PrItemComponent, CiStatusIconComponent],
   templateUrl: './pr-group.component.html',
   styleUrls: ['./pr-group.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -55,12 +56,9 @@ export class PrGroupComponent {
   hasFailingWorkflows = computed(() => this.group().prs.some(pr => pr.workflowStatus === 'failure'));
   isGroupMergeDisabled = computed(() => this.isGroupProcessing() || this.hasFailingWorkflows());
 
-  getCIStatusIcon(status: PrGroup['aggregateCiStatus']): string {
-    switch (status) {
-      case 'success': return '<svg class="w-5 h-5 text-emerald-500" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>';
-      case 'failure': return '<svg class="w-5 h-5 text-rose-500" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>';
-      case 'pending': return '<svg class="w-5 h-5 text-amber-400 animate-spin" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>';
-      default: return '<svg class="w-5 h-5 text-ink-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>';
-    }
-  }
+  /** DOM id of the expandable PR-list region, for aria-controls. */
+  panelId = computed(() => `group-panel-${this.group().title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`);
+
+  ciStatusLabel = computed(() => `Group CI status: ${this.group().aggregateCiStatus}`);
+
 }

--- a/src/app/components/pr-item/pr-item.component.html
+++ b/src/app/components/pr-item/pr-item.component.html
@@ -8,6 +8,7 @@
         class="flex items-center gap-2 text-left shrink-0"
         (click)="onToggleExpanded()"
         [attr.aria-expanded]="expanded()"
+        [attr.aria-controls]="expanded() ? detailsId() : null"
         [attr.aria-label]="'Toggle details for ' + prRef()"
       >
         <svg
@@ -18,9 +19,15 @@
         >
           <path fill-rule="evenodd" d="M6 4a1 1 0 011.707-.707l6 6a1 1 0 010 1.414l-6 6A1 1 0 016 16V4z" clip-rule="evenodd"/>
         </svg>
-        <span [innerHTML]="getCIStatusIcon(pr().ciStatus)" class="shrink-0"></span>
+        <app-ci-status-icon class="shrink-0" [status]="pr().ciStatus" [label]="'CI status: ' + pr().ciStatus" />
       </button>
-      <span [innerHTML]="getWorkflowStatusIcon(pr().workflowStatus)" class="shrink-0"></span>
+      <span
+        class="inline-block size-2 rounded-full shrink-0"
+        [class]="workflowDotClass()"
+        role="img"
+        [attr.aria-label]="workflowDotLabel()"
+        [title]="workflowDotLabel()"
+      ></span>
       <div class="min-w-0">
         <a
           [href]="pr().html_url"
@@ -43,7 +50,7 @@
 
     <!-- Check Runs -->
     @if (expanded() && pr().checkRuns.length > 0) {
-      <div class="mt-2 ml-10 space-y-1.5">
+      <div class="mt-2 ml-10 space-y-1.5" [id]="detailsId()" role="region" [attr.aria-label]="'Checks for ' + prRef()">
         @for (check of pr().checkRuns; track check.id) {
           <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-xs bg-ghost border border-edge rounded-md px-3 py-2">
             <a
@@ -59,12 +66,12 @@
             </a>
             <div class="flex items-center gap-3 text-ink-3">
               <span class="flex items-center gap-1">
-                <span [innerHTML]="getCheckRunStatusIcon(check.status)"></span>
+                <app-check-run-status-icon [status]="check.status" />
                 <span>{{ formatStatus(check.status) }}</span>
               </span>
               @if (check.conclusion) {
                 <span class="flex items-center gap-1">
-                  <span [innerHTML]="getCheckRunConclusionIcon(check.conclusion)"></span>
+                  <app-check-run-conclusion-icon [conclusion]="check.conclusion" />
                   <span>{{ formatConclusion(check.conclusion) }}</span>
                 </span>
               } @else {

--- a/src/app/components/pr-item/pr-item.component.spec.ts
+++ b/src/app/components/pr-item/pr-item.component.spec.ts
@@ -226,4 +226,30 @@ describe('PrItemComponent', () => {
       expect(fixture.componentInstance.age()).toBe('');
     });
   });
+
+  describe('status icons accessibility', () => {
+    it('labels the workflow status dot', () => {
+      const fixture = TestBed.createComponent(PrItemComponent);
+      fixture.componentRef.setInput('pr', makePr({ workflowStatus: 'failure' }));
+      fixture.detectChanges();
+
+      const dot = fixture.nativeElement.querySelector('[aria-label="Workflow failed"]') as HTMLElement;
+      expect(dot).not.toBeNull();
+      expect(dot.classList.contains('bg-rose-500')).toBe(true);
+    });
+
+    it('links the details toggle to the check-run region when expanded', () => {
+      const fixture = TestBed.createComponent(PrItemComponent);
+      fixture.componentRef.setInput('pr', makePr({
+        checkRuns: [{ id: 1, name: 'ci', status: 'completed', conclusion: 'success', html_url: '' }],
+      }));
+      fixture.componentRef.setInput('expanded', true);
+      fixture.detectChanges();
+
+      const toggle = fixture.nativeElement.querySelector('button[aria-expanded]') as HTMLButtonElement;
+      const controls = toggle.getAttribute('aria-controls');
+      expect(controls).toBeTruthy();
+      expect(fixture.nativeElement.querySelector(`[id="${controls}"]`)).not.toBeNull();
+    });
+  });
 });

--- a/src/app/components/pr-item/pr-item.component.ts
+++ b/src/app/components/pr-item/pr-item.component.ts
@@ -1,9 +1,14 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
-import { CiStatus, CheckRun, PullRequest } from '../../models/pull-request.model';
+import { CheckRun, PullRequest } from '../../models/pull-request.model';
+import {
+  CheckRunConclusionIconComponent,
+  CheckRunStatusIconComponent,
+  CiStatusIconComponent,
+} from '../icons/status-icons.component';
 
 @Component({
   selector: 'app-pr-item',
-  imports: [],
+  imports: [CiStatusIconComponent, CheckRunStatusIconComponent, CheckRunConclusionIconComponent],
   templateUrl: './pr-item.component.html',
   styleUrls: ['./pr-item.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -25,6 +30,27 @@ export class PrItemComponent {
     const pr = this.pr();
     const separator = pr.platform === 'gitlab' ? '!' : '#';
     return `${pr.repoOwner}/${pr.repoName}${separator}${pr.number}`;
+  });
+
+  /** DOM id of the expandable check-run region, for aria-controls. */
+  detailsId = computed(() => `pr-details-${this.pr().uid.replace(/[^a-zA-Z0-9-]/g, '-')}`);
+
+  workflowDotClass = computed(() => {
+    switch (this.pr().workflowStatus) {
+      case 'success': return 'bg-emerald-500';
+      case 'failure': return 'bg-rose-500';
+      case 'pending': return 'bg-amber-400';
+      default: return 'bg-ink-3';
+    }
+  });
+
+  workflowDotLabel = computed(() => {
+    switch (this.pr().workflowStatus) {
+      case 'success': return 'Workflow success';
+      case 'failure': return 'Workflow failed';
+      case 'pending': return 'Workflow pending';
+      default: return 'Workflow unknown';
+    }
   });
 
   checksTotal = computed(() => this.pr().checkRuns.length);
@@ -73,53 +99,6 @@ export class PrItemComponent {
 
   onToggleExpanded(): void {
     this.toggleExpanded.emit();
-  }
-
-  getCIStatusIcon(status: CiStatus): string {
-    switch (status) {
-      case 'success': return '<svg class="w-5 h-5 text-emerald-500" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>';
-      case 'failure': return '<svg class="w-5 h-5 text-rose-500" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>';
-      case 'pending': return '<svg class="w-5 h-5 text-amber-400 animate-spin" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>';
-      default: return '<svg class="w-5 h-5 text-ink-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>';
-    }
-  }
-
-  getWorkflowStatusIcon(status: CiStatus): string {
-    switch (status) {
-      case 'success': return '<span class="inline-block size-2 rounded-full bg-emerald-500" role="img" aria-label="Workflow success" title="Workflow success"></span>';
-      case 'failure': return '<span class="inline-block size-2 rounded-full bg-rose-500" role="img" aria-label="Workflow failed" title="Workflow failed"></span>';
-      case 'pending': return '<span class="inline-block size-2 rounded-full bg-amber-400" role="img" aria-label="Workflow pending" title="Workflow pending"></span>';
-      default: return '<span class="inline-block size-2 rounded-full bg-ink-3" role="img" aria-label="Workflow unknown" title="Workflow unknown"></span>';
-    }
-  }
-
-  getCheckRunStatusIcon(status: CheckRun['status']): string {
-    switch (status) {
-      case 'queued':
-        return '<svg class="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8h2a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V10a2 2 0 012-2h2"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 12v9m0-9a4 4 0 100-8h0a4 4 0 000 8z"></path></svg>';
-      case 'in_progress':
-        return '<svg class="w-4 h-4 text-yellow-400 animate-spin" fill="none" viewBox="0 0 24 24" stroke="currentColor"><circle class="opacity-25" cx="12" cy="12" r="10" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V2C5.373 2 1 6.373 1 12h3zm2 5.291A7.962 7.962 0 014 12H1c0 3.042 1.135 5.824 3 7.938l2-2.647z"></path></svg>';
-      case 'completed':
-      default:
-        return '<svg class="w-4 h-4 text-green-400" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414 0L9 11.586 6.707 9.293a1 1 0 10-1.414 1.414l3 3a1 1 0 001.414 0l7-7a1 1 0 000-1.414z" clip-rule="evenodd" /></svg>';
-    }
-  }
-
-  getCheckRunConclusionIcon(conclusion: CheckRun['conclusion']): string {
-    switch (conclusion) {
-      case 'success':
-        return '<svg class="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path></svg>';
-      case 'failure':
-      case 'timed_out':
-      case 'action_required':
-        return '<svg class="w-4 h-4 text-red-500" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path></svg>';
-      case 'cancelled':
-      case 'neutral':
-      case 'skipped':
-        return '<svg class="w-4 h-4 text-gray-400" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM7 9a1 1 0 000 2h6a1 1 0 100-2H7z" clip-rule="evenodd"></path></svg>';
-      default:
-        return '<svg class="w-4 h-4 text-gray-500" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"></path></svg>';
-    }
   }
 
   formatStatus(status: CheckRun['status']): string {


### PR DESCRIPTION
Closes #21 and #25 (the remaining items).

> **Note:** stacked on #87 (`feat/multi-platform-polish`) because both touch `pr-item`; this PR's diff will slim down to its own commit once #87 merges. Please merge #87 first.

## Icons (#21)

Three new components — `CiStatusIconComponent`, `CheckRunStatusIconComponent`, `CheckRunConclusionIconComponent` — replace every HTML-string-returning icon method injected via `[innerHTML]` in `pr-group` and `pr-item`, including the copy-pasted `getCIStatusIcon` duplication the issue called out. **No `[innerHTML]` remains in the codebase.** Templates are compiler-checked and the icons are unit-tested (per-status variants, conclusion grouping).

`CiStatusIcon` exposes an optional `label`: labeled → accessible `role="img"`; unlabeled → decorative (`aria-hidden`). The workflow-status dot became plain template markup with an explicit `aria-label`.

## A11y (#25 items 2–4)

- **aria-controls**: accordion toggles in `pr-group`/`pr-item` reference the `id` of their expanded region (a labeled `role="region"`); omitted while collapsed since the region is conditionally rendered.
- **role="alert"** on the error banner, **role="status"** on the incomplete-results banner, and **role="status" aria-live="polite"** on the loading indicator, so screen readers announce all three.
- Items 1 (per-PR button labels) and 5 (emoji indicators) were already resolved during the redesign — detailed on the issue.

## Tests

221 total (+10): icon component variants and accessible/decorative modes, aria-controls↔region linkage in both accordions (and omission when collapsed), workflow-dot labeling, and the alert/status live regions. Lint and build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)