### PR TITLE
Allow editing configured organizations

### DIFF
--- a/src/app/components/org-switcher/org-switcher.component.html
+++ b/src/app/components/org-switcher/org-switcher.component.html
@@ -140,6 +140,17 @@
             }
             <button
               type="button"
+              (click)="showEditView(conn)"
+              [attr.aria-label]="'Edit ' + conn.organization"
+              class="rounded p-1 text-ink-3 transition-colors hover:bg-ghost hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+              </svg>
+            </button>
+            <button
+              type="button"
               (click)="removeConnection(conn)"
               [attr.aria-label]="'Remove ' + conn.organization"
               class="rounded p-1 text-ink-3 transition-colors hover:bg-rose-500/10 hover:text-rose-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
@@ -167,7 +178,7 @@
         </div>
       </div>
     } @else {
-      <form (submit)="onAddSubmit($event)">
+      <form (submit)="onFormSubmit($event)">
         <div class="flex items-center gap-2 border-b border-edge px-3 py-2.5">
           @if (connections().length > 0) {
             <button
@@ -181,7 +192,7 @@
               </svg>
             </button>
           }
-          <span class="text-[13px] font-medium text-ink">Add organization</span>
+          <span class="text-[13px] font-medium text-ink">{{ formTitle() }}</span>
         </div>
 
         <div class="space-y-3 p-3">
@@ -312,7 +323,7 @@
             [disabled]="!draftValid()"
             class="w-full rounded-md bg-accent px-3 py-2 text-[13px] font-medium text-white transition-colors duration-200 hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           >
-            Add organization
+            {{ submitLabel() }}
           </button>
         </div>
       </form>

--- a/src/app/components/org-switcher/org-switcher.component.spec.ts
+++ b/src/app/components/org-switcher/org-switcher.component.spec.ts
@@ -136,7 +136,7 @@ describe('OrgSwitcherComponent', () => {
       const fixture = createFixture([]);
       openPopover(fixture);
 
-      expect(fixture.componentInstance.view()).toBe('add');
+      expect(fixture.componentInstance.view()).toBe('form');
       expect(overlayEl.querySelector('#draft-org')).not.toBeNull();
     });
 
@@ -322,9 +322,21 @@ describe('OrgSwitcherComponent', () => {
       const emitted: OrgConnection[][] = [];
       fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) => emitted.push(v));
 
-      fixture.componentInstance.addConnection();
+      fixture.componentInstance.saveConnection();
 
       expect(emitted).toHaveLength(0);
+    });
+
+    it('resets a pending draft when navigating back to the list', () => {
+      const fixture = createFixture([ORG_A]);
+      openPopover(fixture);
+      fixture.componentInstance.showAddView();
+      fixture.componentInstance.draftOrg.set('pending');
+
+      fixture.componentInstance.showListView();
+
+      expect(fixture.componentInstance.draftOrg()).toBe('');
+      expect(fixture.componentInstance.editingKey()).toBeNull();
     });
 
     it('shows a back button to the list only when orgs already exist', () => {
@@ -339,6 +351,128 @@ describe('OrgSwitcherComponent', () => {
       const withoutOrgs = createFixture([]);
       openPopover(withoutOrgs);
       expect(overlayEl.querySelector('[aria-label="Back to organization list"]')).toBeNull();
+    });
+  });
+
+  describe('edit organization', () => {
+    const GHES_ORG: OrgConnection = {
+      platform: 'github',
+      host: 'https://ghes.example.com',
+      organization: 'ghes-org',
+      token: 'ghp_ghes',
+      renovateAuthor: 'renovate-bot',
+    };
+
+    function openEditForm(fixture: ReturnType<typeof createFixture>, org: string) {
+      openPopover(fixture);
+      (overlayEl.querySelector(`[aria-label="Edit ${org}"]`) as HTMLButtonElement).click();
+      fixture.detectChanges();
+    }
+
+    it('renders an edit button for each connection', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      openPopover(fixture);
+
+      expect(overlayEl.querySelector('[aria-label="Edit org-a"]')).not.toBeNull();
+      expect(overlayEl.querySelector('[aria-label="Edit org-b"]')).not.toBeNull();
+    });
+
+    it('opens the form prefilled with the connection values', () => {
+      const fixture = createFixture([ORG_A]);
+      openEditForm(fixture, 'org-a');
+
+      const instance = fixture.componentInstance;
+      expect(instance.view()).toBe('form');
+      expect(instance.editingKey()).toBe(connectionKey(ORG_A));
+      expect(instance.draftOrg()).toBe('org-a');
+      expect(instance.draftToken()).toBe('ghp_aaa');
+      // Default host: the advanced section stays collapsed with an empty host field.
+      expect(instance.draftHost()).toBe('');
+      expect(instance.showAdvanced()).toBe(false);
+      expect(overlayEl.textContent).toContain('Edit organization');
+      expect(overlayEl.querySelector('button[type="submit"]')?.textContent).toContain('Save changes');
+    });
+
+    it('prefills host and author and expands the advanced section for a GHES connection', () => {
+      const fixture = createFixture([GHES_ORG]);
+      openEditForm(fixture, 'ghes-org');
+
+      const instance = fixture.componentInstance;
+      expect(instance.draftHost()).toBe('https://ghes.example.com');
+      expect(instance.draftAuthor()).toBe('renovate-bot');
+      expect(instance.showAdvanced()).toBe(true);
+    });
+
+    it('does not flag the edited connection as a duplicate of itself', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      openEditForm(fixture, 'org-a');
+
+      expect(fixture.componentInstance.isDuplicateOrg()).toBe(false);
+      expect(fixture.componentInstance.draftValid()).toBe(true);
+    });
+
+    it('still flags a collision with a different existing connection', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      openEditForm(fixture, 'org-a');
+      fixture.componentInstance.draftOrg.set('org-b');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.isDuplicateOrg()).toBe(true);
+      expect(overlayEl.textContent).toContain('Already added');
+    });
+
+    it('replaces the connection in place on submit and closes the popover', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      openEditForm(fixture, 'org-a');
+      fixture.componentInstance.draftToken.set('ghp_rotated');
+      fixture.detectChanges();
+
+      const emitted: OrgConnection[][] = [];
+      fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) => emitted.push(v));
+
+      (overlayEl.querySelector('form') as HTMLFormElement).dispatchEvent(new Event('submit'));
+      fixture.detectChanges();
+
+      expect(emitted).toEqual([[{ ...ORG_A, token: 'ghp_rotated' }, ORG_B]]);
+      expect(fixture.componentInstance.open()).toBe(false);
+      expect(fixture.componentInstance.editingKey()).toBeNull();
+    });
+
+    it('re-points the org filter when the active connection is renamed', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      fixture.componentRef.setInput('selectedKey', connectionKey(ORG_A));
+      fixture.detectChanges();
+      openEditForm(fixture, 'org-a');
+      fixture.componentInstance.draftOrg.set('org-a-renamed');
+
+      const events: { kind: string; value: unknown }[] = [];
+      fixture.componentInstance.selectedKeyChange.subscribe((v: string | null) =>
+        events.push({ kind: 'selectedKey', value: v }));
+      fixture.componentInstance.connectionsChange.subscribe((v: OrgConnection[]) =>
+        events.push({ kind: 'connections', value: v }));
+
+      fixture.componentInstance.saveConnection();
+
+      // The new selected key must arrive before the connection list so the
+      // parent never holds a key that matches no connection.
+      expect(events.map(e => e.kind)).toEqual(['selectedKey', 'connections']);
+      expect(events[0].value).toBe(connectionKey({ ...ORG_A, organization: 'org-a-renamed' }));
+      expect(events[1].value).toEqual([{ ...ORG_A, organization: 'org-a-renamed' }, ORG_B]);
+    });
+
+    it('does not touch the org filter when editing a non-selected connection', () => {
+      const fixture = createFixture([ORG_A, ORG_B]);
+      fixture.componentRef.setInput('selectedKey', connectionKey(ORG_B));
+      fixture.detectChanges();
+      openEditForm(fixture, 'org-a');
+      fixture.componentInstance.draftOrg.set('org-a-renamed');
+
+      const selectedKeys: (string | null)[] = [];
+      fixture.componentInstance.selectedKeyChange.subscribe((v: string | null) => selectedKeys.push(v));
+
+      fixture.componentInstance.saveConnection();
+
+      expect(selectedKeys).toHaveLength(0);
     });
   });
 });

--- a/src/app/components/org-switcher/org-switcher.component.ts
+++ b/src/app/components/org-switcher/org-switcher.component.ts
@@ -13,7 +13,7 @@ import {
 /**
  * Sidebar organization switcher: a trigger button summarizing the configured
  * connections, with a CDK-overlay popover for selecting the active org filter
- * and for listing, adding, and removing GitHub organizations.
+ * and for listing, adding, editing, and removing organizations.
  */
 @Component({
   selector: 'app-org-switcher',
@@ -29,13 +29,19 @@ export class OrgSwitcherComponent {
   selectedKeyChange = output<string | null>();
 
   open = signal(false);
-  view = signal<'list' | 'add'>('list');
+  view = signal<'list' | 'form'>('list');
   showAdvanced = signal(false);
+  /** Key of the connection being edited; null while adding a new one. */
+  editingKey = signal<string | null>(null);
   draftPlatform = signal<Platform>('github');
   draftOrg = signal('');
   draftToken = signal('');
   draftHost = signal('');
   draftAuthor = signal('');
+
+  isEditing = computed(() => this.editingKey() !== null);
+  formTitle = computed(() => (this.isEditing() ? 'Edit organization' : 'Add organization'));
+  submitLabel = computed(() => (this.isEditing() ? 'Save changes' : 'Add organization'));
 
   readonly platforms: { value: Platform; label: string }[] = [
     { value: 'github', label: 'GitHub' },
@@ -151,11 +157,12 @@ export class OrgSwitcherComponent {
   isDuplicateOrg = computed(() => {
     // Identity is platform + host + org (orgs are case-insensitive); the same
     // org name on a different server or platform is a distinct connection.
+    // When editing, the connection being edited is not its own duplicate.
     const organization = this.draftOrg().trim();
     const host = this.draftHostNormalized();
     if (!organization || !host) return false;
     const key = connectionKey({ platform: this.draftPlatform(), host, organization });
-    return this.connections().some(c => connectionKey(c) === key);
+    return key !== this.editingKey() && this.connections().some(c => connectionKey(c) === key);
   });
 
   setDraftPlatform(platform: Platform): void {
@@ -174,7 +181,7 @@ export class OrgSwitcherComponent {
     } else {
       // With nothing configured yet, the list view would be empty — go straight
       // to the add form.
-      this.view.set(this.connections().length === 0 ? 'add' : 'list');
+      this.view.set(this.connections().length === 0 ? 'form' : 'list');
       this.open.set(true);
     }
   }
@@ -187,10 +194,24 @@ export class OrgSwitcherComponent {
 
   showAddView(): void {
     this.resetDraft();
-    this.view.set('add');
+    this.view.set('form');
+  }
+
+  showEditView(conn: OrgConnection): void {
+    this.editingKey.set(connectionKey(conn));
+    this.draftPlatform.set(conn.platform);
+    this.draftOrg.set(conn.organization);
+    this.draftToken.set(conn.token);
+    const isDefaultHost = conn.host === defaultHostFor(conn.platform);
+    this.draftHost.set(isDefaultHost ? '' : conn.host);
+    this.draftAuthor.set(conn.renovateAuthor ?? '');
+    // Surface the advanced fields when they hold values worth reviewing.
+    this.showAdvanced.set(!isDefaultHost || !!conn.renovateAuthor);
+    this.view.set('form');
   }
 
   showListView(): void {
+    this.resetDraft();
     this.view.set('list');
   }
 
@@ -220,7 +241,7 @@ export class OrgSwitcherComponent {
     this.draftAuthor.set((event.target as HTMLInputElement).value);
   }
 
-  addConnection(): void {
+  saveConnection(): void {
     if (!this.draftValid()) return;
     const host = this.draftHostNormalized() ?? defaultHostFor(this.draftPlatform());
     const renovateAuthor = this.draftAuthor().trim();
@@ -231,14 +252,29 @@ export class OrgSwitcherComponent {
       token: this.draftToken().trim(),
       ...(renovateAuthor ? { renovateAuthor } : {}),
     };
-    this.connectionsChange.emit([...this.connections(), connection]);
+
+    const editingKey = this.editingKey();
+    if (editingKey) {
+      // Follow the edited connection with the org filter if it was active and
+      // its identity changed — emitted before the list so the parent never
+      // sees a selected key that matches no connection.
+      const newKey = connectionKey(connection);
+      if (this.selectedKey() === editingKey && newKey !== editingKey) {
+        this.selectedKeyChange.emit(newKey);
+      }
+      this.connectionsChange.emit(
+        this.connections().map(c => (connectionKey(c) === editingKey ? connection : c)),
+      );
+    } else {
+      this.connectionsChange.emit([...this.connections(), connection]);
+    }
     // Close so the refreshed results are immediately visible.
     this.close();
   }
 
-  onAddSubmit(event: Event): void {
+  onFormSubmit(event: Event): void {
     event.preventDefault();
-    this.addConnection();
+    this.saveConnection();
   }
 
   removeConnection(conn: OrgConnection): void {
@@ -247,6 +283,7 @@ export class OrgSwitcherComponent {
   }
 
   private resetDraft(): void {
+    this.editingKey.set(null);
     this.draftPlatform.set('github');
     this.draftOrg.set('');
     this.draftToken.set('');


### PR DESCRIPTION
Connections could only be added or removed — fixing a typo'd org name or rotating a token meant deleting and re-adding the connection. Each row in the org-switcher popover now has an edit button.

## Changes

- **Edit button per connection row** (pencil icon, next to Remove) that opens the existing form prefilled with the connection's platform, org, and token. The Advanced section is pre-expanded when the connection has a non-default server URL or a Renovate author.
- **Save replaces in place** — the connection keeps its position in the list; the popover closes and a re-search runs (existing `connectionsChange` handling in `App`).
- **Duplicate check excludes the connection being edited**, so saving without renaming is valid, while colliding with a *different* existing connection is still rejected.
- **Org filter follows a renamed connection**: if the connection being edited is the active filter and its identity (platform/host/org) changes, `selectedKeyChange` fires with the new key before `connectionsChange`, so the parent never holds a stale key.
- The shared form view was renamed `'add'` → `'form'` and `addConnection()` → `saveConnection()`; header and submit label switch between "Add organization"/"Edit organization" and "Save changes".

## Testing

- `npm run lint` clean; `npm test` — 241 tests pass (9 new: prefill incl. GHES/advanced, self-duplicate exclusion, collision detection, in-place replace, filter re-pointing, draft reset on back-navigation)
- Playwright against the dev server: edited a self-hosted GitLab connection — form prefilled correctly with Advanced expanded, rename persisted to sessionStorage, list reflects the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)