### PR TITLE
Add a clear button to the group search box

### DIFF
--- a/src/app/components/filter-bar/filter-bar.component.html
+++ b/src/app/components/filter-bar/filter-bar.component.html
@@ -14,13 +14,28 @@
         <path stroke-linecap="round" d="M21 21l-4.35-4.35"/>
       </svg>
       <input
+        #searchInput
         type="text"
         [value]="searchText()"
         (input)="onSearchInput($event)"
         placeholder="Search groups or repos…"
         aria-label="Search PR groups or repositories"
-        class="h-9 w-full sm:w-64 rounded-md border border-edge bg-panel pl-9 pr-3 text-[13px] text-ink placeholder:text-ink-3 transition-all focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
+        class="h-9 w-full sm:w-64 rounded-md border border-edge bg-panel pl-9 text-[13px] text-ink placeholder:text-ink-3 transition-all focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/10"
+        [class.pr-8]="searchText()"
+        [class.pr-3]="!searchText()"
       />
+      @if (searchText()) {
+        <button
+          type="button"
+          (click)="clearSearch(searchInput)"
+          aria-label="Clear search"
+          class="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-ink-3 transition-colors hover:bg-ghost hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+        </button>
+      }
     </div>
 
     <!-- Status segmented control -->

--- a/src/app/components/filter-bar/filter-bar.component.spec.ts
+++ b/src/app/components/filter-bar/filter-bar.component.spec.ts
@@ -30,6 +30,31 @@ describe('FilterBarComponent', () => {
     expect(fixture.componentInstance.searchText()).toBe('ruby');
   });
 
+  it('shows a clear button only while the search box has text', () => {
+    const fixture = TestBed.createComponent(FilterBarComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[aria-label="Clear search"]')).toBeNull();
+
+    fixture.componentInstance.searchText.set('ruby');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[aria-label="Clear search"]')).not.toBeNull();
+  });
+
+  it('clears the search and refocuses the input when the clear button is clicked', () => {
+    const fixture = TestBed.createComponent(FilterBarComponent);
+    fixture.componentInstance.searchText.set('ruby');
+    fixture.detectChanges();
+
+    (fixture.nativeElement.querySelector('[aria-label="Clear search"]') as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.searchText()).toBe('');
+    expect(fixture.nativeElement.querySelector('[aria-label="Clear search"]')).toBeNull();
+    expect(document.activeElement).toBe(fixture.nativeElement.querySelector('input'));
+  });
+
   it('sets the status when a segmented-control tab is clicked', () => {
     const fixture = TestBed.createComponent(FilterBarComponent);
     fixture.detectChanges();

--- a/src/app/components/filter-bar/filter-bar.component.ts
+++ b/src/app/components/filter-bar/filter-bar.component.ts
@@ -31,6 +31,12 @@ export class FilterBarComponent {
     this.searchText.set((event.target as HTMLInputElement).value);
   }
 
+  clearSearch(searchInput: HTMLInputElement): void {
+    this.searchText.set('');
+    // Keep focus in the field so the user can type a new query right away.
+    searchInput.focus();
+  }
+
   onSortChange(event: Event): void {
     this.sortBy.set((event.target as HTMLSelectElement).value as GroupSort);
   }


### PR DESCRIPTION
The only way to reset the group search filter was selecting the text and deleting it. The search field now shows the conventional X on its right side while it contains text.

## Changes

- Clear button rendered inside the search field only when `searchText` is non-empty; the input's right padding widens to make room for it.
- Clicking it empties the filter and returns focus to the input, so a new query can be typed immediately.
- `aria-label="Clear search"` for assistive tech.

## Testing

- `npm run lint` clean; `npm test` — 234 tests pass (2 new: button visibility toggling with text, clear + refocus behavior)
- Playwright against the dev server: button hidden when empty, appears while typing, click clears the filter, refocuses the input, and hides the button again

🤖 Generated with [Claude Code](https://claude.com/claude-code)