### PR TITLE
Fix: PRs in repos without CI showed as "Running"

### DIFF
--- a/src/app/models/pull-request.model.ts
+++ b/src/app/models/pull-request.model.ts
@@ -111,6 +111,8 @@ export interface GitHubCheckRunsResponse {
 
 export interface GitHubCombinedStatusResponse {
   state: 'success' | 'failure' | 'pending' | 'error';
+  /** Number of commit statuses; the API reports state "pending" even when this is 0. */
+  total_count: number;
 }
 
 export interface PullRequest {

--- a/src/app/services/github-provider.service.spec.ts
+++ b/src/app/services/github-provider.service.spec.ts
@@ -191,11 +191,12 @@ describe('GitHubProviderService', () => {
       commits?: number;
       checkRuns?: object[];
       combinedState?: string;
+      statusCount?: number;
     } = {}) {
       return [
         jsonResponse({ commits: overrides.commits ?? 1, head: { sha: 'sha-1' } }),
         jsonResponse({ allow_squash_merge: true, allow_merge_commit: true, allow_rebase_merge: true }),
-        jsonResponse({ state: overrides.combinedState ?? 'pending' }),
+        jsonResponse({ state: overrides.combinedState ?? 'pending', total_count: overrides.statusCount ?? 1 }),
         jsonResponse({ total_count: (overrides.checkRuns ?? []).length, check_runs: overrides.checkRuns ?? [] }),
       ];
     }
@@ -251,6 +252,21 @@ describe('GitHubProviderService', () => {
       expect(pr.workflowStatus).toBe('success');
     });
 
+    it('reports unknown, not pending, for a repo with no CI at all', async () => {
+      // GitHub's combined-status endpoint returns state "pending" for a
+      // commit that has zero statuses; without special-casing total_count 0,
+      // PRs in repos without any CI show as "Running" forever.
+      const responses = detailResponses({ combinedState: 'pending', statusCount: 0, checkRuns: [] });
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      responses.forEach(r => fetchSpy.mockResolvedValueOnce(r));
+
+      const pr = makePr();
+      await provider.fetchPrDetails(pr);
+
+      expect(pr.ciStatus).toBe('unknown');
+      expect(pr.workflowStatus).toBe('unknown');
+    });
+
     it('leaves statuses unknown and never throws when a request fails', async () => {
       vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
 
@@ -275,7 +291,7 @@ describe('GitHubProviderService', () => {
           return Promise.resolve(jsonResponse({ commits: 1, head: { sha: 'sha-1' } }));
         }
         if (u.includes('/status')) {
-          return Promise.resolve(jsonResponse({ state: 'success' }));
+          return Promise.resolve(jsonResponse({ state: 'success', total_count: 1 }));
         }
         return Promise.resolve(jsonResponse({ total_count: 0, check_runs: [] }));
       });
@@ -306,7 +322,7 @@ describe('GitHubProviderService', () => {
           return Promise.resolve(jsonResponse({ commits: 1, head: { sha: 'sha-1' } }));
         }
         if (u.includes('/status')) {
-          return Promise.resolve(jsonResponse({ state: 'success' }));
+          return Promise.resolve(jsonResponse({ state: 'success', total_count: 1 }));
         }
         return Promise.resolve(jsonResponse({ total_count: 0, check_runs: [] }));
       });

--- a/src/app/services/github-provider.service.ts
+++ b/src/app/services/github-provider.service.ts
@@ -90,10 +90,13 @@ export class GitHubProviderService implements GitProvider {
       pr.allowMergeCommit = repoData.allow_merge_commit;
       pr.allowRebaseMerge = repoData.allow_rebase_merge;
 
-      // Get combined CI status for the PR's head commit (as a fallback)
+      // Get combined CI status for the PR's head commit (as a fallback).
+      // A commit with no statuses at all still reports state "pending", so
+      // only trust the state when at least one status exists — otherwise a
+      // repo without CI would show every PR as running.
       const statusUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/status`;
       const statusData = await this.apiRequest<GitHubCombinedStatusResponse>(statusUrl, pr.orgToken);
-      pr.ciStatus = this.mapCombinedStatus(statusData.state);
+      pr.ciStatus = statusData.total_count === 0 ? 'unknown' : this.mapCombinedStatus(statusData.state);
 
       // Get individual check runs for more detailed status
       const checksUrl = `${apiBase}/repos/${pr.repoOwner}/${pr.repoName}/commits/${pr.head.sha}/check-runs`;


### PR DESCRIPTION
PRs in repositories with no CI configured (no GitHub Actions, no commit statuses) were displayed as **Running** indefinitely — observed on puppet-bootstrap/minimal-control#15 and #16.

## Root cause

GitHub's combined-status endpoint (`/commits/{sha}/status`) returns `state: "pending"` even when the commit has **zero** statuses. Verified against the live API for the reported PR's head commit:

```
state: pending | total_count: 0    (and 0 check runs)
```

The provider mapped that state to `ciStatus: 'pending'`, and with no check runs to override it, `workflowStatus` inherited it — rendering the PR as "Running".

## Fix

Only trust the combined state when `total_count > 0`; a commit with no statuses now maps to `'unknown'`, which renders as the neutral gray "Workflow unknown" dot. Such PRs stay individually mergeable but are (as before) excluded from "Merge All Ready" and the group-level "failing will be skipped" logic, which key on an explicit `success`.

The GitLab provider is unaffected — an MR without a pipeline already maps to `'unknown'`.

## Testing

- `npm run lint` clean; `npm test` — 244 tests pass (1 new regression test: pending state with `total_count: 0` and no check runs → `unknown`)
- Existing combined-status mocks updated to carry a realistic `total_count`

🤖 Generated with [Claude Code](https://claude.com/claude-code)