### PR TITLE
Fix: respect merge trains when merging GitLab MRs

### DIFF
--- a/src/app/services/git-provider.contract.spec.ts
+++ b/src/app/services/git-provider.contract.spec.ts
@@ -139,10 +139,11 @@ for (const contract of CONTRACTS) {
     });
 
     it('approveAndMerge rejects when the merge fails', async () => {
-      // First call (approve) succeeds, second (merge) fails.
-      vi.spyOn(globalThis, 'fetch')
-        .mockResolvedValueOnce(new Response('{}', { status: 200 }))
-        .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'merge blocked' }), { status: 405 }));
+      // Every request succeeds except the merge itself.
+      vi.spyOn(globalThis, 'fetch').mockImplementation(url =>
+        Promise.resolve(String(url).endsWith('/merge')
+          ? new Response(JSON.stringify({ message: 'merge blocked' }), { status: 405 })
+          : new Response('{}', { status: 200 })));
 
       await expect(provider.approveAndMerge(contract.makePr())).rejects.toThrow();
     });

--- a/src/app/services/gitlab-provider.service.spec.ts
+++ b/src/app/services/gitlab-provider.service.spec.ts
@@ -213,16 +213,17 @@ describe('GitLabProviderService', () => {
   });
 
   describe('approveAndMerge', () => {
-    it('approves then merges, squashing multi-commit MRs', async () => {
+    it('approves, reads project settings, then merges, squashing multi-commit MRs', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => Promise.resolve(jsonResponse({})));
 
       await provider.approveAndMerge(makeMrPr({ commits: 3 }));
 
       const calls = fetchSpy.mock.calls;
       expect(String(calls[0][0])).toBe('https://gitlab.com/api/v4/projects/42/merge_requests/10/approve');
-      expect(String(calls[1][0])).toBe('https://gitlab.com/api/v4/projects/42/merge_requests/10/merge');
-      expect((calls[1][1] as RequestInit).method).toBe('PUT');
-      expect((calls[1][1] as RequestInit).body).toContain('"squash":true');
+      expect(String(calls[1][0])).toBe('https://gitlab.com/api/v4/projects/42');
+      expect(String(calls[2][0])).toBe('https://gitlab.com/api/v4/projects/42/merge_requests/10/merge');
+      expect((calls[2][1] as RequestInit).method).toBe('PUT');
+      expect((calls[2][1] as RequestInit).body).toContain('"squash":true');
     });
 
     it('does not squash single-commit MRs', async () => {
@@ -230,17 +231,16 @@ describe('GitLabProviderService', () => {
 
       await provider.approveAndMerge(makeMrPr({ commits: 1 }));
 
-      expect((fetchSpy.mock.calls[1][1] as RequestInit).body).toContain('"squash":false');
+      expect((fetchSpy.mock.calls[2][1] as RequestInit).body).toContain('"squash":false');
     });
 
     it('merges anyway when approval is unavailable (Premium-only endpoint)', async () => {
-      const fetchSpy = vi.spyOn(globalThis, 'fetch')
-        .mockResolvedValueOnce(jsonResponse({ message: '404 Not Found' }, 404))
-        .mockResolvedValueOnce(jsonResponse({}));
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => Promise.resolve(jsonResponse({})));
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ message: '404 Not Found' }, 404));
 
       await provider.approveAndMerge(makeMrPr());
 
-      expect(String(fetchSpy.mock.calls[1][0])).toContain('/merge');
+      expect(String(fetchSpy.mock.calls[2][0])).toContain('/merge');
     });
 
     it('propagates non-authorization approval failures without merging', async () => {
@@ -254,9 +254,87 @@ describe('GitLabProviderService', () => {
     it('propagates merge failures', async () => {
       vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(jsonResponse({})) // approve ok
+        .mockResolvedValueOnce(jsonResponse({})) // project settings ok
         .mockResolvedValueOnce(jsonResponse({ message: 'Branch cannot be merged' }, 406));
 
       await expect(provider.approveAndMerge(makeMrPr())).rejects.toThrow('Branch cannot be merged');
+    });
+  });
+
+  describe('merge trains', () => {
+    function routeFetch(project: object, counters?: { settings: number }) {
+      return vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+        if (/\/api\/v4\/projects\/\d+$/.test(String(url))) {
+          if (counters) counters.settings++;
+          return Promise.resolve(jsonResponse(project));
+        }
+        return Promise.resolve(jsonResponse({}));
+      });
+    }
+
+    it('adds the MR to the merge train instead of merging when merge trains are enabled', async () => {
+      const fetchSpy = routeFetch({ merge_trains_enabled: true });
+
+      await provider.approveAndMerge(makeMrPr({ commits: 3 }));
+
+      const urls = fetchSpy.mock.calls.map(c => String(c[0]));
+      expect(urls).toContain('https://gitlab.com/api/v4/projects/42/merge_trains/merge_requests/10');
+      expect(urls.some(u => u.endsWith('/merge'))).toBe(false);
+
+      const trainCall = fetchSpy.mock.calls.find(c => String(c[0]).includes('/merge_trains/'))!;
+      expect((trainCall[1] as RequestInit).method).toBe('POST');
+      expect((trainCall[1] as RequestInit).body).toContain('"when_pipeline_succeeds":true');
+      expect((trainCall[1] as RequestInit).body).toContain('"squash":true');
+    });
+
+    it('merges directly when merge trains are disabled or the field is absent (Free tier)', async () => {
+      const fetchSpy = routeFetch({ merge_trains_enabled: false });
+
+      await provider.approveAndMerge(makeMrPr());
+
+      const urls = fetchSpy.mock.calls.map(c => String(c[0]));
+      expect(urls.some(u => u.endsWith('/merge'))).toBe(true);
+      expect(urls.some(u => u.includes('/merge_trains/'))).toBe(false);
+    });
+
+    it('fetches project settings once per project across merges', async () => {
+      const counters = { settings: 0 };
+      routeFetch({ merge_trains_enabled: true }, counters);
+
+      await provider.approveAndMerge(makeMrPr({ id: 1, number: 10 }));
+      await provider.approveAndMerge(makeMrPr({ id: 2, number: 11 }));
+
+      expect(counters.settings).toBe(1);
+    });
+
+    it('fails the merge rather than bypassing a possible train when settings cannot be read', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+        if (/\/api\/v4\/projects\/\d+$/.test(String(url))) {
+          return Promise.resolve(jsonResponse({ message: 'server exploded' }, 500));
+        }
+        return Promise.resolve(jsonResponse({}));
+      });
+
+      await expect(provider.approveAndMerge(makeMrPr())).rejects.toThrow('server exploded');
+      expect(fetchSpy.mock.calls.map(c => String(c[0])).some(u => u.endsWith('/merge'))).toBe(false);
+    });
+
+    it('does not cache failed settings fetches', async () => {
+      let settingsCalls = 0;
+      vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+        if (/\/api\/v4\/projects\/\d+$/.test(String(url))) {
+          settingsCalls++;
+          return settingsCalls === 1
+            ? Promise.resolve(jsonResponse({ message: 'flaky' }, 500))
+            : Promise.resolve(jsonResponse({ merge_trains_enabled: false }));
+        }
+        return Promise.resolve(jsonResponse({}));
+      });
+
+      await expect(provider.approveAndMerge(makeMrPr())).rejects.toThrow('flaky');
+      await provider.approveAndMerge(makeMrPr());
+
+      expect(settingsCalls).toBe(2);
     });
   });
 

--- a/src/app/services/gitlab-provider.service.ts
+++ b/src/app/services/gitlab-provider.service.ts
@@ -24,9 +24,19 @@ interface GitLabPipelineJob {
   web_url: string;
 }
 
+/** Subset of the Projects API response that affects merge behavior. */
+interface GitLabProject {
+  merge_trains_enabled?: boolean;
+}
+
 /** GitProvider implementation for gitlab.com and self-hosted GitLab (REST v4 API). */
 @Injectable({ providedIn: 'root' })
 export class GitLabProviderService implements GitProvider {
+  // Merge-train configuration is per-project and rarely changes; cache the
+  // promise for the service lifetime. Storing the promise also dedupes
+  // concurrent fetches during a bulk merge.
+  private projectSettingsCache = new Map<string, Promise<GitLabProject>>();
+
   async searchRenovatePrs(connection: OrgConnection): Promise<ProviderSearchResult> {
     const author = connection.renovateAuthor?.trim() || DEFAULT_RENOVATE_AUTHOR;
     const groupPath = encodeURIComponent(connection.organization);
@@ -112,11 +122,28 @@ export class GitLabProviderService implements GitProvider {
       }
     }
 
-    // The project's merge-method settings are enforced server-side; squash
-    // multi-commit MRs to mirror the GitHub provider's behavior.
-    await this.apiRequest<void>(`${mrBase}/merge`, pr.orgToken, 'PUT', {
-      squash: (pr.commits ?? 1) > 1,
-    });
+    // Squash multi-commit MRs to mirror the GitHub provider's behavior; the
+    // project's merge-method settings are enforced server-side.
+    const squash = (pr.commits ?? 1) > 1;
+
+    // Merging directly on a project with merge trains enabled bypasses the
+    // train, so such MRs must be added to the train instead. If the project
+    // settings cannot be read, fail rather than risk skipping the train.
+    const project = await this.getProjectSettings(pr);
+    if (project.merge_trains_enabled) {
+      await this.apiRequest<void>(
+        `${pr.host}/api/v4/projects/${pr.projectId}/merge_trains/merge_requests/${pr.number}`,
+        pr.orgToken,
+        'POST',
+        // when_pipeline_succeeds also covers MRs whose pipeline is still
+        // running; with an already-successful pipeline the MR is added
+        // to the train immediately.
+        { when_pipeline_succeeds: true, squash },
+      );
+      return;
+    }
+
+    await this.apiRequest<void>(`${mrBase}/merge`, pr.orgToken, 'PUT', { squash });
   }
 
   async close(pr: PullRequest): Promise<void> {
@@ -162,6 +189,18 @@ export class GitLabProviderService implements GitProvider {
 
   private mrApiBase(pr: PullRequest): string {
     return `${pr.host}/api/v4/projects/${pr.projectId}/merge_requests/${pr.number}`;
+  }
+
+  private getProjectSettings(pr: PullRequest): Promise<GitLabProject> {
+    const key = `${pr.host}|${pr.projectId}`;
+    let settings = this.projectSettingsCache.get(key);
+    if (!settings) {
+      settings = this.apiRequest<GitLabProject>(`${pr.host}/api/v4/projects/${pr.projectId}`, pr.orgToken);
+      this.projectSettingsCache.set(key, settings);
+      // Don't cache failures — the next merge attempt should retry.
+      settings.catch(() => this.projectSettingsCache.delete(key));
+    }
+    return settings;
   }
 
   private mapPipelineStatus(status: string | undefined): CiStatus {


### PR DESCRIPTION
On a GitLab project with merge trains enabled, "Approve & Merge" called `PUT /merge_requests/:iid/merge`, which merges immediately and bypasses the train entirely (invalidating the train's pipeline queue for everyone else in it).

## Fix

`approveAndMerge` now reads the project's `merge_trains_enabled` setting (`GET /projects/:id`, cached per host+project for the service lifetime — the promise-cache also dedupes concurrent bulk merges) and branches:

- **Trains enabled** → `POST /projects/:id/merge_trains/merge_requests/:iid` with `{ when_pipeline_succeeds: true, squash }`. `when_pipeline_succeeds` also covers MRs whose pipeline is still running; an MR with an already-successful pipeline is added to the train immediately.
- **Trains disabled / field absent (Free tier)** → direct merge as before.
- **Settings unreadable** → the merge fails with the API error rather than silently falling back to a direct merge, since that's exactly the bypass being fixed. Failures are not cached, so a retry refetches.

Behavior note: on a merge-train project the button now means "queue to merge" — the MR merges when its train pipeline passes, so it may stay open briefly after the action succeeds. A subsequent dashboard refresh reflects the final state.

## Testing

- `npm run lint` clean; `npm test` — 249 tests pass (5 new: train routing + payload, Free-tier direct merge, settings cache, fail-closed on unreadable settings, no caching of failures)
- The provider contract test's merge-failure mock now routes by URL so the merge endpoint specifically fails for both providers
- ⚠️ Merge trains are a GitLab Premium feature, so I could not exercise this against a real train — please verify on your instance before relying on it broadly

🤖 Generated with [Claude Code](https://claude.com/claude-code)