### PR TITLE
Wire up the group refresh button

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -225,7 +225,9 @@
               @for (group of filteredGroups(); track group.title) {
                 <app-pr-group
                   [group]="group"
+                  [refreshing]="refreshingGroupTitles().has(group.title)"
                   (toggleGroup)="toggleGroup($event)"
+                  (refreshGroup)="refreshGroupStatuses($event)"
                   (closePr)="closePullRequest($event)"
                   (approveAndMergePr)="approveAndMergePullRequest($event)"
                   (closeGroupPrs)="closeGroupPullRequests($event)"


### PR DESCRIPTION
## Summary

The per-group refresh button (between the PR count badge and "Close All") did nothing when clicked. Both ends were fully implemented — `PrGroupComponent` emits a `refreshGroup` output, and `App.refreshGroupStatuses()` re-fetches CI status and check runs for the group — but the `<app-pr-group>` element in `app.component.html` never bound them together, so the click event emitted into the void.

This adds the two missing bindings:

- `(refreshGroup)="refreshGroupStatuses($event)"` — actually triggers the refresh
- `[refreshing]="refreshingGroupTitles().has(group.title)"` — animates the spinner and disables the button while the refresh is in flight (this also backs the duplicate-refresh guard in `refreshGroupStatuses`)

## Testing

- `npm run lint` — all files pass
- `npm test` — 249 tests pass (12 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)